### PR TITLE
Use %s to avoid embedding Strings which may contain '%' characters.

### DIFF
--- a/lib/mutant/reporter/cli.rb
+++ b/lib/mutant/reporter/cli.rb
@@ -270,7 +270,7 @@ module Mutant
       # @api private
       #
       def print_killer(color, word, killer)
-        puts(colorize(color, "#{word}: #{killer.identification} (%02.2fs)" % killer.runtime))
+        puts(colorize(color, "%s: %s (%02.2fs)" % [word, killer.identification, killer.runtime]))
       end
 
       # Test for output to tty


### PR DESCRIPTION
Fixed a bug in `print_killer` when the method name is `#%`.
