### PR TITLE
Update mutant.gemspec

### DIFF
--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -16,10 +16,9 @@ Gem::Specification.new do |gem|
   gem.executables       = [ 'mutant' ]
 
   gem.add_runtime_dependency('to_source',           '~> 0.2.14')
-  gem.add_runtime_dependency('ice_nine',            '~> 0.6.0')
   gem.add_runtime_dependency('descendants_tracker', '~> 0.0.1')
-  gem.add_runtime_dependency('backports',           '~> 2.7.0')
-  gem.add_runtime_dependency('adamantium',          '~> 0.0.5')
+  gem.add_runtime_dependency('backports',           '~> 2.8.2')
+  gem.add_runtime_dependency('adamantium',          '~> 0.0.6')
   gem.add_runtime_dependency('inflecto',            '~> 0.0.2')
   gem.add_runtime_dependency('equalizer',           '~> 0.0.1')
   gem.add_runtime_dependency('abstract_type',       '~> 0.0.2')


### PR DESCRIPTION
No need to explicitly set ice_nine dependency since adamantium has a hard dep on it
