### PR TITLE
Add mutators to force true and false conditions in if and unless nodes

### DIFF
--- a/lib/mutant/mutator/node/if.rb
+++ b/lib/mutant/mutator/node/if.rb
@@ -21,6 +21,8 @@ module Mutant
           emit_inverted_condition 
           emit_deleted_if_branch
           emit_deleted_else_branch
+          emit_true_if_branch
+          emit_false_if_branch
         end
 
         # Test if attribute is non nil literal
@@ -71,6 +73,26 @@ module Mutant
         def emit_deleted_if_branch
           body = else_branch || return
           emit_self(condition, body, nil)
+        end
+
+        # Emit true if branch
+        #
+        # @return [undefined]
+        #
+        # @api private
+        #
+        def emit_true_if_branch
+          emit_self(new(Rubinius::AST::TrueLiteral), if_branch, else_branch)
+        end
+
+        # Emit false if branch
+        #
+        # @return [undefined]
+        #
+        # @api private
+        #
+        def emit_false_if_branch
+          emit_self(new(Rubinius::AST::FalseLiteral), if_branch, else_branch)
         end
 
         # Return if_branch of node

--- a/spec/unit/mutant/mutator/node/if_statement/mutation_spec.rb
+++ b/spec/unit/mutant/mutator/node/if_statement/mutation_spec.rb
@@ -26,6 +26,12 @@ describe Mutant::Mutator, 'if statement' do
       # mutations of else body
       mutants << 'if self.condition; true;  else true;  end' 
       mutants << 'if self.condition; true;  else nil;   end' 
+
+      # mutation of condition to always be true
+      mutants << 'if true; true; else false; end'
+
+      # mutation of condition to always be false
+      mutants << 'if false; true; else false; end'
     end
 
     it_should_behave_like 'a mutator'
@@ -40,6 +46,8 @@ describe Mutant::Mutator, 'if statement' do
       mutants << 'if condition; true; end'
       mutants << 'unless condition; false; end'
       mutants << 'unless condition; nil; end'
+      mutants << 'unless true; true; end'
+      mutants << 'unless false; true; end'
     end
 
     it_should_behave_like 'a mutator'
@@ -53,6 +61,8 @@ describe Mutant::Mutator, 'if statement' do
       mutants << 'if !condition; true; end'
       mutants << 'if condition; false; end'
       mutants << 'if condition; nil; end'
+      mutants << 'if true; true; end'
+      mutants << 'if false; true; end'
     end
 
     it_should_behave_like 'a mutator'


### PR DESCRIPTION
@mbj this branch forces true and false for if/unless nodes.

I tried it against Axiom::Types and it successfully found that one mutation that I noticed it missed, but it also identified a couple of others that I had missed. I am almost done killing the mutations it found.

I'd recommend running this against your 100% mutant covered code and see what it shows you.
