### PR TITLE
Change Mutant::Killer#run_with_benchmark to use Benchmark.measure

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 16
-total_score: 607
+total_score: 604

--- a/lib/mutant.rb
+++ b/lib/mutant.rb
@@ -1,3 +1,4 @@
+require 'benchmark'
 require 'set'
 require 'adamantium'
 require 'ice_nine'

--- a/lib/mutant/killer.rb
+++ b/lib/mutant/killer.rb
@@ -89,10 +89,10 @@ module Mutant
     # @api private
     #
     def run_with_benchmark
-      start_time = Time.now
-      @killed = run
-      end_time = Time.now
-      @runtime = end_time - start_time
+      times = Benchmark.measure do
+        @killed = run
+      end
+      @runtime = times.real
     end
 
     # Run killer


### PR DESCRIPTION
This should return the actual CPU time rather than the real elapsed time, which is not the best measurement since it can be affected by other processes on the machine.
