### PR TITLE
Change forked run method to consider some errors as success

### DIFF
--- a/lib/mutant/killer/rspec.rb
+++ b/lib/mutant/killer/rspec.rb
@@ -20,7 +20,12 @@ module Mutant
         # TODO: replace with real streams from configuration
         require 'stringio'
         null = StringIO.new
-        !::RSpec::Core::Runner.run(command_line_arguments, null, null).zero?
+        args = command_line_arguments
+        begin
+          !::RSpec::Core::Runner.run(args, null, null).zero?
+        rescue StandardError
+          true
+        end
       end
 
       # Return command line arguments


### PR DESCRIPTION
Some errors caused by a mutation, like ArgumentError and NameError indicate that the mutation results in code that fails with the specs. I think these should be considered successful.

@mbj I opened this PR for discussion. I mentioned it in another comment, but I have tested this with axiom and it resolved a few of the syntax error problems that were reported. The problem is I'm not sure if this has any negative side effects, so I wanted to run this by you since you're much more familiar with the whole system.
