### PR TITLE
Add timeout to stop killer after 5 seconds

### DIFF
--- a/TODO
+++ b/TODO
@@ -15,7 +15,6 @@ Mutations:
   * Mutate Block catch "def foo(&block)" and block pass "foo(&block)"
   * Mutate super arguments just like send arguments
   * Binary operator mutations
-  * Add timeout to terminate infinite loops
 
     Example of a negative mutation:
       Mutations on local variables and arguments prefixed with an underscore would be emitted as

--- a/lib/mutant/killer.rb
+++ b/lib/mutant/killer.rb
@@ -3,6 +3,8 @@ module Mutant
   class Killer
     include Adamantium::Flat, AbstractType, Equalizer.new(:strategy, :mutation, :killed?)
 
+    TIMEOUT_THRESHOLD = 5
+
     # Return strategy
     #
     # @return [Strategy]
@@ -90,7 +92,11 @@ module Mutant
     #
     def run_with_benchmark
       times = Benchmark.measure do
-        @killed = run
+        @killed = begin
+          Timeout.timeout(TIMEOUT_THRESHOLD) { run }
+        rescue Timeout::Error
+          true
+        end
       end
       @runtime = times.real
     end


### PR DESCRIPTION
@mbj this commit adds a timeout to long running mutations that have potentially created an infinite loop.

I realize this might not actually work in some cases, like when running --rspec-unit and --rspec-full but I wanted to start discussion on it somewhere since I just saw a case in ice_nine where a mutation became infinite.

I wonder if simply making the timeout configurable would be enough? Then if someone has a long running spec suite, they could make the timeout 2x longer than whatever it takes to run. In my case, since I'm using --rspec-dm2 I would set the timeout to 1 second or something low since no example takes anywhere near that much time to run.
