### PR TITLE
Recommend users install the beta version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Installation
 
 Install the gem `mutant` via your preferred method.
 
+```ruby
+gem install mutant -v<version>.beta<n>
+```
+
 Examples
 --------
 


### PR DESCRIPTION
Because just running straight gem install will result in dependency issues it should be recommended that users straight up issue a -`v0.3.0.beta8` for example, just to avoid any issues.
