### PR TITLE
Correct eurucamp conference name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are some presentations about mutant in the wild:
 
 * [RailsConf 2014](http://railsconf.com/) / http://confreaks.com/videos/3333-railsconf-mutation-testing-with-mutant
 * [Wrocloverb 2014](http://wrocloverb.com/) / https://www.youtube.com/watch?v=rz-lFKEioLk
-* [Eurocamp-2013](http://2013.eurucamp.org/) / FrOSCon-2013 http://slid.es/markusschirp/mutation-testing
+* [eurucamp 2013](http://2013.eurucamp.org/) / FrOSCon-2013 http://slid.es/markusschirp/mutation-testing
 * [Cologne.rb](http://www.colognerb.de/topics/mutation-testing-mit-mutant) / https://github.com/DonSchado/colognerb-on-mutant/blob/master/mutation_testing_slides.pdf
 
 Blog-Posts


### PR DESCRIPTION
change eurucamp name to the official writing (lower case + _ru_ for Ruby)
