### PR TITLE
Fix examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ Examples
 ```
 cd virtus
 # Run mutant on virtus namespace
-mutant --include lib --require virtus --use rspec ::Virtus*
+mutant --include lib --require virtus --use rspec Virtus*
 # Run mutant on specific virtus class
-mutant --include lib --require virtus --use rspec ::Virtus::Attribute
+mutant --include lib --require virtus --use rspec Virtus::Attribute
 # Run mutant on specific virtus class method
-mutant --include lib --require virtus --use rspec ::Virtus::Attribute.build
+mutant --include lib --require virtus --use rspec Virtus::Attribute.build
 # Run mutant on specific virtus instance method
-mutant --include lib --require virtus --use rspec ::Virtus::Attribute#type
+mutant --include lib --require virtus --use rspec Virtus::Attribute#type
 ```
 
 Subjects


### PR DESCRIPTION
The README still showed the old CLI patterns starting with `::`, which stopped working from version 0.5.19. Fixes #203.
