### PR TITLE
Change WarningExpectation to report all warnings that are not ignored

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 18
-total_score: 973
+total_score: 967

--- a/lib/mutant/subject/method/instance.rb
+++ b/lib/mutant/subject/method/instance.rb
@@ -25,13 +25,7 @@ module Mutant
         # @api private
         #
         def prepare
-          expected_warnings =
-            if RUBY_ENGINE.eql?('ruby') && name.equal?(:initialize)
-              ["#{__FILE__}:#{__LINE__ + 5}: warning: undefining `initialize' may cause serious problems\n"]
-            else
-              []
-            end
-          WarningExpectation.new(expected_warnings).execute do
+          WarningExpectation.new(["#{__FILE__}:#{__LINE__ + 1}: warning: undefining `#{name}' may cause serious problems\n"]).execute do
             scope.send(:undef_method, name)
           end
           self


### PR DESCRIPTION
- It does not seem necessary to care if the ruby implementation
  raises a warning about initialize being redefined or not. It seems better
  to just raise if anything unexpected happens.
