### PR TITLE
Delete duplicate 'mutant' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'mutant', path: '.'
-
 gemspec name: 'mutant'
 
 gem 'devtools', git: 'https://github.com/rom-rb/devtools.git'


### PR DESCRIPTION
This might be unnecessary, but I figured I'd start a conversation (because I'll certainly learn something).

When I run bundle install I get the following warning:

``` plain
Your Gemfile lists the gem mutant (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```

My guess is that it's because the Gemfile references the gemspec, and that perhaps the gemspec implicitly requires the gem defined within it.
