### PR TITLE
Change test when using Rspec3 to properly match

### DIFF
--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -162,7 +162,7 @@ Options:
 
       it_should_behave_like 'a cli parser'
 
-      let(:expected_integration) { Mutant::Integration::Rspec::Rspec2.new }
+      let(:expected_integration) { Mutant::Integration::Rspec.build }
     end
 
     context 'with version flag' do


### PR DESCRIPTION
Hoping this is not an "expect('a').to eql('a')" situation on my part
