### PR TITLE
Fix miscellaneous typos

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -71,7 +71,7 @@ Changes:
 
 * Report selected tests in progress runner
 * Fix scope of rspec selections to include meaningful parents.
-* Add short circuts on already dead mutations under multiple test selections.
+* Add short circuits on already dead mutations under multiple test selections.
 
 # v0.5.16 2014-05-27
 
@@ -98,7 +98,7 @@ Changes:
 
 Changes:
 
-* Imporve reporting of isolation problems
+* Improve reporting of isolation problems
 * Centralize test selection
 * Report selected tests
 * Report rspec output on noop failures
@@ -117,7 +117,7 @@ Changes:
 * Fix crash on while and until without body
 * Better require highjack based zombifier
 * Do not mutate nthref $1 to gvar $0
-* Use faster duplicate guarding hashing AST::Node intances
+* Use faster duplicate guarding hashing AST::Node instances
 * Fix lots of shadowed invalid ASTs
 * Fix undefine initialize warnings, Closes #175
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The old flags were removed.  It allows to define very fine grained specs, or coa
 Support
 -------
 
-I'm very happy to receive/answer feedback/questions and critism.
+I'm very happy to receive/answer feedback/questions and criticism.
 
 Your options:
 

--- a/lib/mutant.rb
+++ b/lib/mutant.rb
@@ -194,7 +194,7 @@ require 'mutant/zombifier'
 require 'mutant/zombifier/file'
 
 module Mutant
-  # Repoen class to initialize constant to avoid dep circle
+  # Reopen class to initialize constant to avoid dep circle
   class Config
     DEFAULT = new(
       debug:             false,

--- a/lib/mutant/cli.rb
+++ b/lib/mutant/cli.rb
@@ -2,11 +2,11 @@ require 'optparse'
 
 module Mutant
 
-  # Comandline parser
+  # Commandline parser
   class CLI
     include Adamantium::Flat, Equalizer.new(:config), Procto.call(:config)
 
-    # Error faild when CLI argv is invalid
+    # Error failed when CLI argv is invalid
     Error = Class.new(RuntimeError)
 
     EXIT_FAILURE = 1

--- a/lib/mutant/context.rb
+++ b/lib/mutant/context.rb
@@ -1,5 +1,5 @@
 module Mutant
-  # An abstract context where mutations can be appied to.
+  # An abstract context where mutations can be applied to.
   class Context
     include Adamantium::Flat, AbstractType, Concord::Public.new(:source_path)
 

--- a/lib/mutant/expression.rb
+++ b/lib/mutant/expression.rb
@@ -22,8 +22,8 @@ module Mutant
     # Error raised on invalid expressions
     class InvalidExpressionError < RuntimeError; end
 
-    # Error raised on ambigous expressions
-    class AmbigousExpressionError < RuntimeError; end
+    # Error raised on ambiguous expressions
+    class AmbiguousExpressionError < RuntimeError; end
 
     # Initialize expression
     #
@@ -127,7 +127,7 @@ module Mutant
       when 1
         expressions.first
       else
-        fail AmbigousExpressionError, "Ambigous expression: #{input.inspect}"
+        fail AmbiguousExpressionError, "Ambiguous expression: #{input.inspect}"
       end
     end
 

--- a/lib/mutant/isolation.rb
+++ b/lib/mutant/isolation.rb
@@ -1,5 +1,5 @@
 module Mutant
-  # Module providing isolationg
+  # Module providing isolation
   module Isolation
     Error = Class.new(RuntimeError)
 

--- a/lib/mutant/matcher.rb
+++ b/lib/mutant/matcher.rb
@@ -23,7 +23,7 @@ module Mutant
     # @return [self]
     #   if block given
     #
-    # @return [Enumerabe<Subject>]
+    # @return [Enumerable<Subject>]
     #   otherwise
     #
     abstract_method :each

--- a/lib/mutant/matcher/method/singleton.rb
+++ b/lib/mutant/matcher/method/singleton.rb
@@ -80,7 +80,7 @@ module Mutant
           end
         end
 
-        # Test if reciver name matches context
+        # Test if receiver name matches context
         #
         # @param [Parser::AST::Node] node
         #

--- a/lib/mutant/meta/example/dsl.rb
+++ b/lib/mutant/meta/example/dsl.rb
@@ -78,7 +78,7 @@ module Mutant
           self
         end
 
-        # Add singleotn mutations
+        # Add singleton mutations
         #
         # @return [undefined]
         #

--- a/lib/mutant/mutator.rb
+++ b/lib/mutant/mutator.rb
@@ -69,7 +69,7 @@ module Mutant
       dispatch
     end
 
-    # Test if generated object is not guarded from emmitting
+    # Test if generated object is not guarded from emitting
     #
     # @param [Object] object
     #

--- a/lib/mutant/mutator/node.rb
+++ b/lib/mutant/mutator/node.rb
@@ -190,7 +190,7 @@ module Mutant
       # Return parent type
       #
       # @return [Symbol] type
-      #   if parent with type is presnet
+      #   if parent with type is present
       #
       # @return [nil]
       #   otherwise

--- a/lib/mutant/mutator/node/if.rb
+++ b/lib/mutant/mutator/node/if.rb
@@ -23,7 +23,7 @@ module Mutant
           mutate_else_branch
         end
 
-        # Emit conditon mutations
+        # Emit condition mutations
         #
         # @return [undefined]
         #

--- a/lib/mutant/mutator/node/literal/fixnum.rb
+++ b/lib/mutant/mutator/node/literal/fixnum.rb
@@ -40,7 +40,7 @@ module Mutant
             children.first
           end
 
-        end # Fixnuma
+        end # Fixnum
       end # Literal
     end # Node
   end # Mutator

--- a/lib/mutant/mutator/registry.rb
+++ b/lib/mutant/mutator/registry.rb
@@ -74,7 +74,7 @@ module Mutant
       #
       # @return [undefined]
       #
-      # @raise [DuplcateTypeError]
+      # @raise [DuplicateTypeError]
       #   raised when the node type is a duplicate
       #
       # @api private

--- a/lib/mutant/mutator/util.rb
+++ b/lib/mutant/mutator/util.rb
@@ -3,7 +3,7 @@ module Mutant
     # Namespace for utility mutators
     class Util < self
 
-      # Run ulitity mutator
+      # Run utility mutator
       #
       # @param [Object] object
       # @param [Object] parent

--- a/lib/mutant/result.rb
+++ b/lib/mutant/result.rb
@@ -90,7 +90,7 @@ module Mutant
 
     # Hook called when module gets included
     #
-    # @param [Class, Module] hosto
+    # @param [Class, Module] host
     #
     # @return [undefined]
     #
@@ -262,7 +262,7 @@ module Mutant
     class Mutation
       include Result, Anima.new(:runtime, :mutation, :test_results, :index)
 
-      # Test if mutation was handeled successfully
+      # Test if mutation was handled successfully
       #
       # @return [Boolean]
       #

--- a/lib/mutant/zombifier/file.rb
+++ b/lib/mutant/zombifier/file.rb
@@ -1,6 +1,6 @@
 module Mutant
   class Zombifier
-    # File containing source beeing zombified
+    # File containing source being zombified
     class File
       include Adamantium::Flat, Concord::Public.new(:path), AST::Sexp
 

--- a/spec/support/mutation_verifier.rb
+++ b/spec/support/mutation_verifier.rb
@@ -28,7 +28,7 @@ class MutationVerifier
 
 private
 
-  # Return unexpected mutationso
+  # Return unexpected mutations
   #
   # @return [Array<Parser::AST::Node>]
   #
@@ -71,7 +71,7 @@ private
     ].join("\n")
   end
 
-  # Return missing mutationso
+  # Return missing mutations
   #
   # @return [Array<Parser::AST::Node>]
   #

--- a/spec/support/project.rb
+++ b/spec/support/project.rb
@@ -23,7 +23,7 @@ module Corpus
     # Verify mutation coverage
     #
     # @return [self]
-    #   if successufl
+    #   if successful
     #
     # @raise [Exception]
     #

--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -38,7 +38,7 @@ describe Mutant::CLI do
       end
     end
 
-    context 'when report signalls error' do
+    context 'when report signals error' do
       let(:report_success) { false }
 
       it 'exits failure' do

--- a/spec/unit/mutant/expression_spec.rb
+++ b/spec/unit/mutant/expression_spec.rb
@@ -30,7 +30,7 @@ describe Mutant::Expression do
       let(:input) { 'test-syntax' }
 
       it 'raises an exception' do
-        expect { subject }.to raise_error(Mutant::Expression::AmbigousExpressionError, 'Ambigous expression: "test-syntax"')
+        expect { subject }.to raise_error(Mutant::Expression::AmbiguousExpressionError, 'Ambiguous expression: "test-syntax"')
       end
     end
   end

--- a/spec/unit/mutant/matcher/method/instance_spec.rb
+++ b/spec/unit/mutant/matcher/method/instance_spec.rb
@@ -68,7 +68,7 @@ describe Mutant::Matcher::Method::Instance do
     end
 
     context 'when method is defined multiple times' do
-      context 'on differend lines' do
+      context 'on different lines' do
         let(:base) { __LINE__ }
         class self::Foo
           def bar
@@ -96,7 +96,7 @@ describe Mutant::Matcher::Method::Instance do
         it_should_behave_like 'a method matcher'
       end
 
-      context 'on the same line with differend scope' do
+      context 'on the same line with different scope' do
         let(:base) { __LINE__ }
         class self::Foo
           def self.bar; end; def bar(_arg); end

--- a/spec/unit/mutant/matcher/method/singleton_spec.rb
+++ b/spec/unit/mutant/matcher/method/singleton_spec.rb
@@ -92,7 +92,7 @@ describe Mutant::Matcher::Method::Singleton, '#each' do
     end
 
     context 'when defined multiple times in the same line' do
-      context 'with method on differend scope' do
+      context 'with method on different scope' do
         let(:base) { __LINE__ }
         module self::Namespace
           module Foo; end

--- a/spec/unit/mutant/reporter/cli_spec.rb
+++ b/spec/unit/mutant/reporter/cli_spec.rb
@@ -291,7 +291,7 @@ describe Mutant::Reporter::CLI do
   describe '#report' do
     subject { object.report(result) }
 
-    context 'with full covergage' do
+    context 'with full coverage' do
       let(:mutation_result_success) { true }
 
       it 'writes report to output' do


### PR DESCRIPTION
Mostly in comments and documentation, but one method name was corrected to match documentation.
