### PR TITLE
Use correct Ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Mutant is a mutation testing tool for Ruby.
 The idea is that if code can be changed and your tests do not notice, either that code isn't being covered
 or it does not have a speced side effect.
 
-Mutant supports MRI and RBX 1.9, 2.0 and 2.1, while support for JRuby is planned.
+Mutant supports MRI and RBX 2.0 and 2.1, while support for JRuby is planned.
 It should also work under any Ruby engine that supports POSIX-fork(2) semantics.
 
 Mutant uses a pure Ruby [parser](https://github.com/whitequark/parser) and an [unparser](https://github.com/mbj/unparser)


### PR DESCRIPTION
The gemspec specifies Ruby >= 2.0.0 so remove mention of 1.9
