### PR TITLE
Bump parser dependency to allow 2.2.2.1

### DIFF
--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_runtime_dependency('parser',        '~> 2.2.0.2')
+  gem.add_runtime_dependency('parser',        '~> 2.2', '>= 2.2.0.2')
   gem.add_runtime_dependency('ast',           '~> 2.0')
   gem.add_runtime_dependency('diff-lcs',      '~> 1.2')
   gem.add_runtime_dependency('parallel',      '~> 1.3')


### PR DESCRIPTION
RuboCop 0.30.1 depends on parser 2.2.2.1, which means it can’t work in a project where mutant requires parser 2.2.0.x. This allows mutant to work with parser 2.2.2.1.