### PR TITLE
update tput to support terminfo on mac

### DIFF
--- a/lib/mutant/reporter/cli/tput.rb
+++ b/lib/mutant/reporter/cli/tput.rb
@@ -18,7 +18,7 @@ module Mutant
           reset   = capture('tput reset')
           save    = capture('tput sc') if reset
           restore = capture('tput rc') if save
-          clean   = capture('tput ed') if restore
+          clean   = capture('tput ed') || capture('tput cd') if restore
           new(reset + save, restore + clean) if clean
         end
 

--- a/spec/unit/mutant/reporter/cli/tput_spec.rb
+++ b/spec/unit/mutant/reporter/cli/tput_spec.rb
@@ -34,5 +34,15 @@ RSpec.describe Mutant::Reporter::CLI::Tput do
 
       it { should be(nil) }
     end
+
+    context 'when ed fails' do
+      let(:tput_ed?) { false }
+      let(:tput_cd?) { true }
+      before do
+        expect_command('tput cd', '[cd]', tput_cd?)
+      end
+      its(:prepare) { should eql('[reset][sc]') }
+      its(:restore) { should eql('[rc][cd]')    }
+    end
   end
 end


### PR DESCRIPTION
For some reason clr_eos on the mac responds to "cd" not "ed".
All other codes seem to respond to the cap name, but this one responds
to the tcap code

fixes #313