### PR TITLE
Move test classes (Foo, Bar) from global space to anonymous local

### DIFF
--- a/spec/unit/mutant/matcher/methods/instance_spec.rb
+++ b/spec/unit/mutant/matcher/methods/instance_spec.rb
@@ -1,39 +1,40 @@
 RSpec.describe Mutant::Matcher::Methods::Instance, '#each' do
-  let(:object) { described_class.new(env, Foo) }
+  let(:object) { described_class.new(env, class_under_test) }
   let(:env)    { Fixtures::TEST_ENV            }
 
   subject { object.each { |matcher| yields << matcher } }
 
   let(:yields) { [] }
 
-  module Bar
-    def method_d
+  let(:class_under_test) do
+    parent = Module.new do
+      def method_d
+      end
+
+      def method_e
+      end
     end
 
-    def method_e
+    Class.new do
+      include parent
+
+      private :method_d
+
+      public
+
+      def method_a
+      end
+
+      protected
+
+      def method_b
+      end
+
+      private
+
+      def method_c
+      end
     end
-  end
-
-  class Foo
-    include Bar
-
-    private :method_d
-
-  public
-
-    def method_a
-    end
-
-  protected
-
-    def method_b
-    end
-
-  private
-
-    def method_c
-    end
-
   end
 
   let(:subject_a) { double('Subject A') }
@@ -45,11 +46,11 @@ RSpec.describe Mutant::Matcher::Methods::Instance, '#each' do
   before do
     matcher = Mutant::Matcher::Method::Instance
     allow(matcher).to receive(:new)
-      .with(env, Foo, Foo.instance_method(:method_a)).and_return([subject_a])
+      .with(env, class_under_test, class_under_test.instance_method(:method_a)).and_return([subject_a])
     allow(matcher).to receive(:new)
-      .with(env, Foo, Foo.instance_method(:method_b)).and_return([subject_b])
+      .with(env, class_under_test, class_under_test.instance_method(:method_b)).and_return([subject_b])
     allow(matcher).to receive(:new)
-      .with(env, Foo, Foo.instance_method(:method_c)).and_return([subject_c])
+      .with(env, class_under_test, class_under_test.instance_method(:method_c)).and_return([subject_c])
   end
 
   it 'should yield expected subjects' do

--- a/spec/unit/mutant/matcher/methods/singleton_spec.rb
+++ b/spec/unit/mutant/matcher/methods/singleton_spec.rb
@@ -1,33 +1,35 @@
 RSpec.describe Mutant::Matcher::Methods::Singleton, '#each' do
-  let(:object) { described_class.new(env, Foo) }
+  let(:object) { described_class.new(env, class_under_test) }
   let(:env)    { Fixtures::TEST_ENV            }
 
   subject { object.each { |matcher| yields << matcher } }
 
   let(:yields) { [] }
 
-  module Bar
-    def method_d
+  let(:class_under_test) do
+    parent = Module.new do
+      def method_d
+      end
+
+      def method_e
+      end
     end
 
-    def method_e
+    Class.new do
+      extend parent
+
+      def self.method_a
+      end
+
+      def self.method_b
+      end
+      class << self; protected :method_b; end
+
+      def self.method_c
+      end
+      private_class_method :method_c
+
     end
-  end
-
-  class Foo
-    extend Bar
-
-    def self.method_a
-    end
-
-    def self.method_b
-    end
-    class << self; protected :method_b; end
-
-    def self.method_c
-    end
-    private_class_method :method_c
-
   end
 
   let(:subject_a) { double('Subject A') }
@@ -39,11 +41,11 @@ RSpec.describe Mutant::Matcher::Methods::Singleton, '#each' do
   before do
     matcher = Mutant::Matcher::Method::Singleton
     allow(matcher).to receive(:new)
-      .with(env, Foo, Foo.method(:method_a)).and_return([subject_a])
+      .with(env, class_under_test, class_under_test.method(:method_a)).and_return([subject_a])
     allow(matcher).to receive(:new)
-      .with(env, Foo, Foo.method(:method_b)).and_return([subject_b])
+      .with(env, class_under_test, class_under_test.method(:method_b)).and_return([subject_b])
     allow(matcher).to receive(:new)
-      .with(env, Foo, Foo.method(:method_c)).and_return([subject_c])
+      .with(env, class_under_test, class_under_test.method(:method_c)).and_return([subject_c])
   end
 
   it 'should yield expected subjects' do


### PR DESCRIPTION
In rspec, defining a class in a describe actually describes in the global scope (e.g. outside the describe).

So this was complaining that the class was defined multiple times. Which is true.

Just let me know where you want to move and what to call.
(probably shouldn't be defining classes in specs in general)

