### PR TITLE
single spec for all literal tests

### DIFF
--- a/test_app/spec/unit/test_app/literal/command_spec.rb
+++ b/test_app/spec/unit/test_app/literal/command_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-RSpec.describe TestApp::Literal, '#command' do
-  subject { object.command(double) }
-
-  let(:object) { described_class.new }
-
-  it { should be(object) }
-end

--- a/test_app/spec/unit/test_app/literal/string_spec.rb
+++ b/test_app/spec/unit/test_app/literal/string_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-RSpec.describe TestApp::Literal, '#string' do
-  subject { object.string }
-
-  let(:object) { described_class.new }
-
-  it { should eql('string') }
-end

--- a/test_app/spec/unit/test_app/literal_spec.rb
+++ b/test_app/spec/unit/test_app/literal_spec.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+RSpec.describe TestApp::Literal do
+
+  describe '#command' do
+    subject { object.command(double) }
+
+    let(:object) { described_class.new }
+
+    it { should be(object) }
+  end
+
+  describe '#string' do
+    subject { object.string }
+
+    let(:object) { described_class.new }
+
+    it { should eql('string') }
+  end
+end


### PR DESCRIPTION
This code confuses me, as 99% of the time, there is a single spec per lib file.
Textmate and sublime uses this assumption to switch between tests too.

Do these really need to be separate files?

Is the problem here that the test app is too simple?