### PR TITLE
Add ruby 2.0 to allowed failures on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
 matrix:
   allow_failures:
     - rvm: rbx
+    - rvm: '2.0'
 notifications:
   irc:
     channels:


### PR DESCRIPTION
* We see 50% of the builds for 2.0 failing for probably travis specific reasons.
* Other CIs / local environments are fine on 2.0