### PR TITLE
Fix expected coverage to use an approximate match

### DIFF
--- a/config/flog.yml
+++ b/config/flog.yml
@@ -1,2 +1,2 @@
 ---
-threshold: 30.9
+threshold: 33.2

--- a/lib/mutant/reporter/cli/printer.rb
+++ b/lib/mutant/reporter/cli/printer.rb
@@ -203,7 +203,7 @@ module Mutant
             info 'Mutant configuration:'
             info 'Matcher:         %s',      object.matcher.inspect
             info 'Integration:     %s',      object.integration.name
-            info 'Expect Coverage: %0.2f%%', (object.expected_coverage * 100)
+            info 'Expect Coverage: %0.2f%%', (object.expected_coverage * 100).floor(2)
             info 'Jobs:            %d',      object.jobs
             info 'Includes:        %s',      object.includes.inspect
             info 'Requires:        %s',      object.requires.inspect
@@ -244,8 +244,8 @@ module Mutant
             info 'Runtime:         %0.2fs',    runtime
             info 'Killtime:        %0.2fs',    killtime
             info 'Overhead:        %0.2f%%',   overhead_percent
-            status 'Coverage:        %0.2f%%', coverage_percent
-            status 'Expected:        %0.2f%%', (env.config.expected_coverage * 100)
+            status 'Coverage:        %0.2f%%', coverage_percent.floor(2)
+            status 'Expected:        %0.2f%%', (env.config.expected_coverage * 100).floor(2)
             self
           end
 

--- a/lib/mutant/result.rb
+++ b/lib/mutant/result.rb
@@ -85,6 +85,11 @@ module Mutant
     class Env
       include Coverage, Result, Anima.new(:runtime, :env, :subject_results)
 
+      # Number of decimals to round the expected coverage successor for upper
+      # bounds comparison. The scale 2 was chosen to match the reported
+      # coverage amount.
+      ROUND_SCALE = 2
+
       # Test if run is successful
       #
       # @return [Boolean]
@@ -92,7 +97,9 @@ module Mutant
       # @api private
       #
       def success?
-        coverage.eql?(env.config.expected_coverage)
+        expected = env.config.expected_coverage
+        succ     = expected.floor(ROUND_SCALE) + 10**-ROUND_SCALE
+        (expected...succ).cover?(coverage)
       end
       memoize :success?
 

--- a/spec/unit/mutant/result/env_spec.rb
+++ b/spec/unit/mutant/result/env_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Mutant::Result::Env do
   let(:config) do
     double(
       'Config',
-      expected_coverage: Rational(1, 1)
+      expected_coverage: expected
     )
   end
 
@@ -32,19 +32,29 @@ RSpec.describe Mutant::Result::Env do
     )
   end
 
-  let(:results) { 1 }
-  let(:killed)  { 0 }
+  let(:expected) { Rational(1) }
+  let(:results)  { 9           }
+  let(:killed)   { 0           }
 
   describe '#success?' do
     subject { object.success? }
 
-    context 'when coverage matches expectation' do
-      let(:killed) { 1 }
+    context 'when coverage matches expectation exactly' do
+      let(:killed) { 9 }
+
+      it { should be(true) }
+    end
+
+    context 'when coverage matches expectation approximately' do
+      let(:expected) { Rational('0.8888') }
+      let(:killed)   { 8                  }
 
       it { should be(true) }
     end
 
     context 'when coverage does not match expectation' do
+      let(:killed) { 8 }
+
       it { should be(false) }
     end
   end


### PR DESCRIPTION
This branch simplifies how expected coverage matches the actual coverage. It should fit people's mental model more closely, while not giving up too much precision.

The idea is that since Mutant reports coverage with 2 decimal places, this code makes sure that the comparison takes that into account. If the coverage is actually `74.333` but reported as `74.33` this will allow for people to specify `74.33` as the expected coverage and have it match. The code will match anything equal to or greater than `74.33` and less than `74.34` (but not equal to).

I realize this is a departure from the *exact* match method we've used, but it's not really that far off. it matches what how most people would expect things to work. Unless the printer is going to be changed to display the exact `Rational` state I think this, or something like it, is the best way forward for matching coverage.

[Fix #323]