### PR TITLE
Fix gemspec reference to rspec integration tests.

### DIFF
--- a/mutant-rspec.gemspec
+++ b/mutant-rspec.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
 
   gem.require_paths    = %w[lib]
   gem.files            = `git ls-files -- lib/mutant/integration/rspec.rb`.split("\n")
-  gem.test_files       = `git ls-files -- spec/{unit,integration}/mutant/rspec/**/*.rb}`.split("\n")
+  gem.test_files       = `git ls-files -- spec/integration/mutant/rspec_spec.rb}`.split("\n")
   gem.extra_rdoc_files = %w[TODO LICENSE]
 
   gem.add_runtime_dependency('mutant', "~> #{gem.version}")

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |gem|
 
   gem.require_paths    = %w[lib]
 
-  mutant_rspec_files   = `git ls-files -- lib/mutant/integration/rspec{,2,3}.rb`.split("\n")
+  mutant_integration_files   = `git ls-files -- lib/mutant/integration/*.rb`.split("\n")
 
-  gem.files            = `git ls-files`.split("\n") - mutant_rspec_files
+  gem.files            = `git ls-files`.split("\n") - mutant_integration_files
   gem.test_files       = `git ls-files -- spec/{unit,integration}`.split("\n")
   gem.extra_rdoc_files = %w[TODO LICENSE]
   gem.executables      = %w[mutant]


### PR DESCRIPTION
rspec integration tests are no longer in multiple files
change gemspec to reflect that fact.
