### PR TITLE
Introduce Minitest integration

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 18
-total_score: 1200
+total_score: 1231

--- a/config/reek.yml
+++ b/config/reek.yml
@@ -80,6 +80,7 @@ TooManyStatements:
   - Mutant::CLI#add_debug_options
   - Mutant::CLI#add_environment_options
   - Mutant::Isolation::Fork#self.call
+  - Mutant::Integration::Minitest#call
   - Mutant::Reporter::CLI::Printer::Config#run
   - Mutant::Reporter::CLI::Printer::EnvProgress#run
   - Mutant::Runner#run_driver

--- a/lib/mutant/integration/minitest.rb
+++ b/lib/mutant/integration/minitest.rb
@@ -1,0 +1,180 @@
+require 'minitest'
+
+# monkey patch for minitest
+module Minitest
+  # Prevent autorun from running tests when the VM closes
+  #
+  # Mutant needs control about the exit status of the VM and
+  # the moment of test execution
+  #
+  # @api private
+  #
+  # @return [nil]
+  def self.autorun
+  end
+
+end # Minitest
+
+module Mutant
+  class Integration
+    # Minitest integration
+    class Minitest < self
+      TEST_METHOD_PREFIX = 'test_'.freeze
+
+      register 'minitest'
+
+      # Compose a runnable with test method
+      #
+      # This looks actually like a missing object on minitest implementation.
+      class TestCase
+        include Adamantium, Concord.new(:klass, :test_method)
+
+        # Identification string
+        #
+        # @return [String]
+        #
+        # @api private
+        def identification
+          "minitest:#{klass}##{test_method}"
+        end
+        memoize :identification
+
+        # Run test case
+        #
+        # @param [Object] reporter
+        #
+        # @return [Boolean]
+        #
+        # @api private
+        def call(reporter)
+          ::Minitest::Runnable.run_one_method(klass, test_method, reporter)
+          reporter.passed?
+        end
+
+        # Cover expression syntaxes
+        #
+        # @return [Array<String>]
+        #
+        # @api private
+        def expression_syntax
+          klass.cover_expression
+        end
+
+      end # TestCase
+
+      private_constant(*constants(false))
+
+      # Setup integration
+      #
+      # @return [self]
+      #
+      # @api private
+      def setup
+        Dir.glob('./test/**/{test_*,*_test}.rb').each(&method(:require))
+        self
+      end
+
+      # Call test integration
+      #
+      # @param [Array<Tests>] tests
+      #
+      # @return [Result::Test]
+      #
+      # rubocop:disable MethodLength
+      #
+      # @api private
+      def call(tests)
+        test_cases = tests.map(&all_tests_index.method(:fetch)).to_set
+
+        output   = StringIO.new
+        reporter = self.class.make_reporter(output)
+
+        start = Time.now
+        passed = test_cases.all? { |test| test.call(reporter) }
+        output.rewind
+
+        Result::Test.new(
+          passed:  passed,
+          tests:   tests,
+          output:  output.read,
+          runtime: Time.now - start
+        )
+      end
+
+      # All tests exposed by this integration
+      #
+      # @return [Array<Test>]
+      #
+      # @api private
+      def all_tests
+        all_tests_index.keys
+      end
+      memoize :all_tests
+
+    private
+
+      # The index of all tests to runnable test cases
+      #
+      # @return [Hash<Test,TestCase>]
+      #
+      # @api private
+      def all_tests_index
+        self.class.all_test_cases.each_with_object({}) do |test_case, index|
+          index[construct_test(test_case)] = test_case
+        end
+      end
+      memoize :all_tests_index
+
+      # Construct test from test case
+      #
+      # @param [TestCase]
+      #
+      # @return [Test]
+      #
+      # @api private
+      def construct_test(test_case)
+        Test.new(
+          id:         test_case.identification,
+          expression: config.expression_parser.(test_case.expression_syntax)
+        )
+      end
+
+      # All minitest test cases
+      #
+      # @return [Array<TestCase>]
+      #
+      # @api private
+      def self.all_test_cases
+        ::Minitest::Runnable.runnables.flat_map(&method(:test_case))
+      end
+
+      # Turn a minitest runnable into its test cases
+      #
+      # @param [Object] runnable
+      #
+      # @return [Array<TestCase>]
+      #
+      # @api private
+      def self.test_case(runnable)
+        runnable.runnable_methods.each_with_object([]) do |method_name, test_cases|
+          next unless method_name.start_with?(TEST_METHOD_PREFIX)
+          test_cases << TestCase.new(runnable, method_name)
+        end
+      end
+      private_class_method :test_case
+
+      # Reporter used for a specific mutation kjill
+      #
+      # @param [StringIO] output
+      #
+      # @api private
+      def self.make_reporter(output)
+        reporter = ::Minitest::CompositeReporter.new
+        reporter << ::Minitest::SummaryReporter.new(output)
+        reporter << ::Minitest::ProgressReporter.new(output)
+        reporter
+      end
+
+    end # Minitest
+  end # Integration
+end # Mutant

--- a/mutant-minitest.gemspec
+++ b/mutant-minitest.gemspec
@@ -1,0 +1,24 @@
+# encoding: utf-8
+#
+require File.expand_path('../lib/mutant/version', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.name        = 'mutant-minitest'
+  gem.version     = Mutant::VERSION.dup
+  gem.authors     = ['Markus Schirp']
+  gem.email       = ['mbj@schirp-dso.com']
+  gem.description = 'Minitest integration for mutant'
+  gem.summary     = gem.description
+  gem.homepage    = 'https://github.com/mbj/mutant'
+  gem.license     = 'MIT'
+
+  gem.require_paths    = %w[lib]
+  gem.files            = `git ls-files -- lib/mutant/integration/minitest.rb`.split("\n")
+  gem.test_files       = `git ls-files -- spec/integration/mutant/minitest.rb`.split("\n")
+  gem.extra_rdoc_files = %w[TODO LICENSE]
+
+  gem.add_runtime_dependency('mutant', "~> #{gem.version}")
+  gem.add_runtime_dependency('minitest', '>= 5.3.0')
+
+  gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
+end

--- a/spec/integration/mutant/minitest_spec.rb
+++ b/spec/integration/mutant/minitest_spec.rb
@@ -1,0 +1,10 @@
+Rspec.describe 'minitest integration', mutant: false do
+
+  let(:base_cmd) { 'bundle exec mutant -I test -I lib --require test_app --use minitest' }
+
+  context 'Minitest 5.5.0' do
+    let(:gemfile)  { 'Gemfile.minitest-stdlib' }
+
+    it_behaves_like 'framework integration'
+  end
+end

--- a/spec/shared/framework_integration_behavior.rb
+++ b/spec/shared/framework_integration_behavior.rb
@@ -16,10 +16,11 @@ RSpec.shared_examples_for 'framework integration' do
   specify 'it allows to exclude mutations' do
     cli = <<-CMD.split("\n").join(' ')
       #{base_cmd}
+      --ignore-subject TestApp::Literal#uncovered_string
       TestApp::Literal#string
       TestApp::Literal#uncovered_string
-        --ignore-subject TestApp::Literal#uncovered_string
     CMD
+
     expect(Kernel.system(cli)).to be(true)
   end
 

--- a/test_app/Gemfile.minitest-stdlib
+++ b/test_app/Gemfile.minitest-stdlib
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'minitest', '~> 5.5.0'
+gem 'mutant',          path: '../'
+gem 'mutant-minitest', path: '../'
+gem 'adamantium'

--- a/test_app/test/test_helper.rb
+++ b/test_app/test/test_helper.rb
@@ -1,0 +1,23 @@
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+
+require 'test_app'
+require 'minitest/autorun'
+
+# require spec support files and shared behavior
+Dir[File.expand_path('../{support,shared}/**/*.rb', __FILE__)].each do |file|
+  require file
+end
+
+class TestAppTest < Minitest::Test
+  def self.cover(expression)
+    @expression = expression
+  end
+
+  def self.cover_expression
+    unless @expression
+      fail "Cover expression for #{self} is not specified"
+    end
+
+    @expression
+  end
+end

--- a/test_app/test/unit/test_app/literal_test.rb
+++ b/test_app/test/unit/test_app/literal_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class TestApp::LiteralTest < TestAppTest
+  cover 'TestApp::Literal*'
+
+  def test_command
+    object = ::TestApp::Literal.new
+    subject = object.command('x')
+
+    assert_equal object, subject
+  end
+
+  def test_string
+    object = ::TestApp::Literal.new
+    subject = object.string
+
+    assert_equal 'string', subject
+  end
+end


### PR DESCRIPTION
Hi

This is working for me, but looking for some input.

1. Suggestions on how to handle lib and test requires? I though the mutant -I test -I lib would have loaded them into the LOAD_PATH, but they were not set. Should I load these from config? Is that available?
2. Suggestions on loading in the tests? (this seems to be the way rake testtask does it)
3. What belongs in run vs setup?
4. How much output do you want from minitest while running tests?
5. Do you want to start imposing "describe" type tests?
6. Do you want to support "minitest spec tests too?"

cleanup:
1. need to squash
2. need to remove rakefile stuff
3. Want to include attribution, but this code has reworked so many times by different people that I'm not sure which git commits use as my base. And a majority of the lines have been changed. You have a preference for a bunch of commits vs clean git history?

Thanks
