### PR TITLE
Simplify Rails setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ Assuming you are using rspec, you can mutation test Rails models by adding the f
 
 ```ruby
 group :test do
-  gem 'mutant'
   gem 'mutant-rspec'
 end
 ```


### PR DESCRIPTION
As `mutant` is already specified as a dependency in `mutant-rspec .gemspec`, it seems unnecessary to list it in the Gemfile.