### PR TITLE
Build mri-2.1 on circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 ---
 machine:
   ruby:
-    version: '2.2'
+    version: '2.1'
 dependencies:
   pre:
     - bundle -v | grep -Fx "Bundler version 1.10.6" || gem install bundler --version 1.10.6


### PR DESCRIPTION
Simulate a build matrix on circle through a 2.1 specific branch. *NOT INTENT FOR MERGE*.

Till CircleCI got a nativ matrix support, I'll sporadically rebase this branch to make sure before releases master is green.