### PR TITLE
Change integrations to reference config object

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 18
-total_score: 1208
+total_score: 1194

--- a/lib/mutant.rb
+++ b/lib/mutant.rb
@@ -184,7 +184,7 @@ module Mutant
     DEFAULT = new(
       debug:             false,
       fail_fast:         false,
-      integration:       Integration::Null.new,
+      integration:       Integration::Null,
       matcher:           Matcher::Config::DEFAULT,
       includes:          EMPTY_ARRAY,
       requires:          EMPTY_ARRAY,

--- a/lib/mutant/env.rb
+++ b/lib/mutant/env.rb
@@ -7,6 +7,7 @@ module Mutant
       :cache,
       :subjects,
       :matchable_scopes,
+      :integration,
       :selector,
       :mutations
     )
@@ -63,7 +64,7 @@ module Mutant
 
       config.isolation.call do
         mutation.insert
-        config.integration.call(tests)
+        integration.call(tests)
       end
     rescue Isolation::Error => error
       Result::Test.new(

--- a/lib/mutant/env/bootstrap.rb
+++ b/lib/mutant/env/bootstrap.rb
@@ -57,16 +57,18 @@ module Mutant
       #
       # @api private
       #
+      # rubocop:disable MethodLength
+      #
       def env
         subjects = matched_subjects
-
         Env.new(
           actor_env:        Actor::Env.new(Thread),
           config:           config,
           cache:            cache,
           subjects:         subjects,
           matchable_scopes: matchable_scopes,
-          selector:         Selector::Expression.new(config.integration),
+          integration:      @integration,
+          selector:         Selector::Expression.new(@integration),
           mutations:        subjects.flat_map(&:mutations)
         )
       end
@@ -101,6 +103,7 @@ module Mutant
       def infect
         config.includes.each(&$LOAD_PATH.method(:<<))
         config.requires.each(&method(:require))
+        @integration = config.integration.new(config).setup
       end
 
       # Try to turn scope into expression

--- a/lib/mutant/integration.rb
+++ b/lib/mutant/integration.rb
@@ -2,7 +2,7 @@ module Mutant
 
   # Abstract base class mutant test framework integrations
   class Integration
-    include AbstractType, Adamantium::Flat, Equalizer.new
+    include AbstractType, Adamantium::Flat, Concord.new(:config)
 
     REGISTRY = {}
 
@@ -29,7 +29,7 @@ module Mutant
     # @api private
     #
     def self.lookup(name)
-      REGISTRY.fetch(name).new
+      REGISTRY.fetch(name)
     end
 
     # Register integration
@@ -42,8 +42,6 @@ module Mutant
     #
     def self.register(name)
       REGISTRY[name] = self
-
-      define_method(:name) { name }
     end
     private_class_method :register
 

--- a/lib/mutant/integration/rspec.rb
+++ b/lib/mutant/integration/rspec.rb
@@ -19,7 +19,7 @@ module Mutant
     #   for unique reference.
     class Rspec < self
 
-      ALL                  = Mutant::Expression.parse('*')
+      ALL_EXPRESSION       = Expression.parse('*').freeze
       EXPRESSION_CANDIDATE = /\A([^ ]+)(?: )?/.freeze
       LOCATION_DELIMITER   = ':'.freeze
       EXIT_SUCCESS         = 0
@@ -33,7 +33,8 @@ module Mutant
       #
       # @api private
       #
-      def initialize
+      def initialize(*)
+        super
         @output = StringIO.new
         @runner = RSpec::Core::Runner.new(RSpec::Core::ConfigurationOptions.new(CLI_OPTIONS))
         @world  = RSpec.world
@@ -134,7 +135,7 @@ module Mutant
           Expression.parse(metadata.fetch(:mutant_expression))
         else
           match = EXPRESSION_CANDIDATE.match(metadata.fetch(:full_description))
-          Expression.try_parse(match.captures.first) || ALL
+          Expression.try_parse(match.captures.first) || ALL_EXPRESSION
         end
       end
 

--- a/lib/mutant/runner.rb
+++ b/lib/mutant/runner.rb
@@ -34,8 +34,6 @@ module Mutant
     #  @api private
     #
     def run_mutation_analysis
-      config.integration.setup
-
       @result = run_driver(Parallel.async(mutation_test_config))
       reporter.report(@result)
     end

--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -1,19 +1,19 @@
-RSpec.shared_examples_for 'an invalid cli run' do
-  it 'raises error' do
-    expect do
-      subject
-    end.to raise_error(Mutant::CLI::Error, expected_message)
-  end
-end
-
-RSpec.shared_examples_for 'a cli parser' do
-  it { expect(subject.config.integration).to eql(expected_integration)       }
-  it { expect(subject.config.reporter).to eql(expected_reporter)             }
-  it { expect(subject.config.matcher).to eql(expected_matcher_config) }
-end
-
 RSpec.describe Mutant::CLI do
   let(:object) { described_class }
+
+  shared_examples_for 'an invalid cli run' do
+    it 'raises error' do
+      expect do
+        subject
+      end.to raise_error(Mutant::CLI::Error, expected_message)
+    end
+  end
+
+  shared_examples_for 'a cli parser' do
+    it { expect(subject.config.integration).to eql(expected_integration) }
+    it { expect(subject.config.reporter).to eql(expected_reporter)       }
+    it { expect(subject.config.matcher).to eql(expected_matcher_config)  }
+  end
 
   describe '.run' do
     subject { object.run(arguments) }
@@ -67,7 +67,7 @@ RSpec.describe Mutant::CLI do
 
     # Defaults
     let(:expected_filter)         { Morpher.evaluator(s(:true))      }
-    let(:expected_integration)    { Mutant::Integration::Null.new    }
+    let(:expected_integration)    { Mutant::Integration::Null        }
     let(:expected_reporter)       { Mutant::Config::DEFAULT.reporter }
     let(:expected_matcher_config) { default_matcher_config           }
 
@@ -152,7 +152,7 @@ Options:
 
         it_should_behave_like 'a cli parser'
 
-        let(:expected_integration) { Mutant::Integration::Rspec.new }
+        let(:expected_integration) { Mutant::Integration::Rspec }
       end
 
       context 'when integration does NOT exist' do

--- a/spec/unit/mutant/env/boostrap_spec.rb
+++ b/spec/unit/mutant/env/boostrap_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Mutant::Env::Bootstrap do
     )
   end
 
+  let(:integration) { Mutant::Integration::Null.new(config) }
+
   let(:expected_env) do
     Mutant::Env.new(
       cache:            Mutant::Cache.new,
@@ -16,8 +18,9 @@ RSpec.describe Mutant::Env::Bootstrap do
       matchable_scopes: [],
       mutations:        [],
       config:           config,
-      selector:         Mutant::Selector::Expression.new(config.integration),
-      actor_env:        Mutant::Actor::Env.new(Thread)
+      selector:         Mutant::Selector::Expression.new(integration),
+      actor_env:        Mutant::Actor::Env.new(Thread),
+      integration:      integration
     )
   end
 

--- a/spec/unit/mutant/env_spec.rb
+++ b/spec/unit/mutant/env_spec.rb
@@ -8,18 +8,15 @@ RSpec.describe Mutant::Env do
         selector:         selector,
         subjects:         [],
         mutations:        [],
-        matchable_scopes: []
+        matchable_scopes: [],
+        integration:      Mutant::Integration::Null.new(config)
       )
     end
 
     let(:config) do
-      Mutant::Config::DEFAULT.update(
-        isolation:   isolation,
-        integration: integration
-      )
+      Mutant::Config::DEFAULT.update(isolation: isolation)
     end
 
-    let(:integration)  { double('Integration')                                                   }
     let(:isolation)    { double('Isolation')                                                     }
     let(:mutation)     { Mutant::Mutation::Evil.new(mutation_subject, Mutant::AST::Nodes::N_NIL) }
     let(:wrapped_node) { double('Wrapped Node')                                                  }
@@ -59,7 +56,6 @@ RSpec.describe Mutant::Env do
         expect(mutation_subject).to receive(:prepare).and_return(mutation_subject).ordered
         expect(context).to receive(:root).with(s(:nil)).and_return(wrapped_node).ordered
         expect(Mutant::Loader::Eval).to receive(:call).with(wrapped_node, mutation_subject).and_return(nil).ordered
-        expect(integration).to receive(:call).with(tests).and_return(test_result).ordered
       end
 
       include_examples 'mutation kill'

--- a/spec/unit/mutant/integration/rspec_spec.rb
+++ b/spec/unit/mutant/integration/rspec_spec.rb
@@ -1,10 +1,10 @@
 require 'mutant/integration/rspec'
 
 RSpec.describe Mutant::Integration::Rspec do
-  let(:object) { described_class.new }
+  let(:object) { described_class.new(Mutant::Config::DEFAULT) }
 
-  let(:options)       { double('options')                           }
-  let(:runner)        { double('runner')                            }
+  let(:options) { double('options') }
+  let(:runner)  { double('runner')  }
 
   let(:example_a) do
     double(

--- a/spec/unit/mutant/integration_spec.rb
+++ b/spec/unit/mutant/integration_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Mutant::Integration do
     Class.new(described_class)
   end
 
-  let(:object) { class_under_test.new }
+  let(:object) { class_under_test.new(Mutant::Config::DEFAULT) }
 
   describe '#setup' do
     subject { object.setup }
@@ -14,7 +14,7 @@ end
 
 RSpec.describe Mutant::Integration::Null do
 
-  let(:object) { described_class.new }
+  let(:object) { described_class.new(Mutant::Config::DEFAULT) }
 
   describe '#all_tests' do
     subject { object.all_tests }

--- a/spec/unit/mutant/reporter/cli/printer/config_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/config_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Config do
       it_reports(<<-REPORT)
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 100.00%
         Jobs:            1
         Includes:        []
@@ -22,7 +22,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Config do
       it_reports(<<-REPORT)
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []

--- a/spec/unit/mutant/reporter/cli/printer/env_progress_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/env_progress_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
       it_reports <<-'STR'
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []
@@ -33,7 +33,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
       it_reports <<-'STR'
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []
@@ -56,7 +56,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
       it_reports <<-'STR'
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []

--- a/spec/unit/mutant/reporter/cli/printer/env_result_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/env_result_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvResult do
       -----------------------
       Mutant configuration:
       Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-      Integration:     null
+      Integration:     Mutant::Integration::Null
       Expect Coverage: 100.00%
       Jobs:            1
       Includes:        []

--- a/spec/unit/mutant/reporter/cli/printer/status_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/status_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
       it_reports <<-REPORT
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 100.00%
         Jobs:            1
         Includes:        []
@@ -33,7 +33,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
         it_reports <<-REPORT
           Mutant configuration:
           Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-          Integration:     null
+          Integration:     Mutant::Integration::Null
           Expect Coverage: 10.00%
           Jobs:            1
           Includes:        []
@@ -59,7 +59,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
         it_reports(<<-REPORT)
           Mutant configuration:
           Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-          Integration:     null
+          Integration:     Mutant::Integration::Null
           Expect Coverage: 100.00%
           Jobs:            1
           Includes:        []
@@ -86,7 +86,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
           it_reports(<<-REPORT)
             Mutant configuration:
             Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-            Integration:     null
+            Integration:     Mutant::Integration::Null
             Expect Coverage: 100.00%
             Jobs:            1
             Includes:        []
@@ -115,7 +115,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
           it_reports(<<-REPORT)
             Mutant configuration:
             Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-            Integration:     null
+            Integration:     Mutant::Integration::Null
             Expect Coverage: 100.00%
             Jobs:            1
             Includes:        []

--- a/spec/unit/mutant/reporter/cli_spec.rb
+++ b/spec/unit/mutant/reporter/cli_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Mutant::Reporter::CLI do
       it_reports(<<-REPORT)
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 100.00%
         Jobs:            1
         Includes:        []
@@ -137,7 +137,7 @@ RSpec.describe Mutant::Reporter::CLI do
       it_reports(<<-REPORT)
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []
@@ -156,7 +156,7 @@ RSpec.describe Mutant::Reporter::CLI do
     it_reports(<<-REPORT)
       Mutant configuration:
       Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-      Integration:     null
+      Integration:     Mutant::Integration::Null
       Expect Coverage: 100.00%
       Jobs:            1
       Includes:        []
@@ -182,7 +182,7 @@ RSpec.describe Mutant::Reporter::CLI do
       it_reports(<<-REPORT)
         [tput-restore]Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config match_expressions=[] subject_ignores=[] subject_selects=[]>
-        Integration:     null
+        Integration:     Mutant::Integration::Null
         Expect Coverage: 100.00%
         Jobs:            1
         Includes:        []
@@ -224,6 +224,5 @@ RSpec.describe Mutant::Reporter::CLI do
         end
       end
     end
-
   end
 end

--- a/spec/unit/mutant/runner_spec.rb
+++ b/spec/unit/mutant/runner_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe Mutant::Runner do
 
     before do
       expect(reporter).to receive(:start).with(env).ordered
-      expect(integration).to receive(:setup).ordered
       expect(Mutant::Parallel).to receive(:async).with(parallel_config).and_return(driver).ordered
     end
 


### PR DESCRIPTION
* Future changes depend on this one
* Also fixes the smell of "stateless" integration objects we had in the
  past