### PR TITLE
Change Mutant::Isolation.call to use block form of IO.pipe

### DIFF
--- a/spec/support/corpus.rb
+++ b/spec/support/corpus.rb
@@ -210,7 +210,7 @@ module MutantSpec
         if block_given?
           yield
         else
-          fail 'System command failed!'
+          fail "System command failed!: #{arguments.join(' ')}"
         end
       end
 


### PR DESCRIPTION
This branch changes `Mutant::Isolation.call` to use block form of `IO.pipe` to ensure open file handles are closed when no longer used.