### PR TITLE
Change --since to only target code under the cwd

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 18
-total_score: 1208
+total_score: 1213

--- a/config/reek.yml
+++ b/config/reek.yml
@@ -131,6 +131,7 @@ UtilityFunction:
   - Mutant::Integration::Rspec#parse_example
   - Mutant::Meta::Example::Verification#format_mutation
   - Mutant::Repository::Diff#tracks? # intentional, private
+  - Mutant::Repository::Diff#within_working_directory? # intentional, private
   - Mutant::Reporter::CLI::Format::Progressive#new_buffer
   - Mutant::Reporter::CLI::Printer::StatusProgressive#object # False positive calls super
   - Mutant::Integration::Rspec#parse_expression # intentional, private

--- a/config/reek.yml
+++ b/config/reek.yml
@@ -43,12 +43,12 @@ NestedIterators:
   - Mutant#self.singleton_subclass_instance
   - Mutant::CLI#parse
   - Mutant::Isolation::Fork#self.call
-  - Mutant::Mutator::Util::Array::Element#dispatch
-  - Mutant::Mutator::Node::Resbody#mutate_captures
   - Mutant::Mutator::Node::Arguments#emit_argument_mutations
+  - Mutant::Mutator::Node::Resbody#mutate_captures
+  - Mutant::Mutator::Util::Array::Element#dispatch
+  - Mutant::Parallel::Master#run
   - Mutant::RequireHighjack#self.call
   - Mutant::Selector::Expression#call
-  - Mutant::Parallel::Master#run
   - Parser::Lexer#self.new
   max_allowed_nesting: 1
   ignore_iterators: []
@@ -70,26 +70,26 @@ TooManyMethods:
   enabled: true
   exclude:
   - Mutant::CLI
-  - Mutant::Mutator::Node
   - Mutant::Meta::Example::Verification
+  - Mutant::Mutator::Node
   - Mutant::Parallel::Master
   max_methods: 10
 TooManyStatements:
   enabled: true
   exclude:
-  - Mutant::Isolation::Fork#self.call
-  - Mutant::Reporter::CLI::Printer::EnvProgress#run
-  - Mutant::Reporter::CLI::Printer::Config#run
-  - Mutant::Zombifier::File#self.find
-  - Mutant::CLI#add_environment_options
   - Mutant::CLI#add_debug_options
+  - Mutant::CLI#add_environment_options
+  - Mutant::Isolation::Fork#self.call
+  - Mutant::Reporter::CLI::Printer::Config#run
+  - Mutant::Reporter::CLI::Printer::EnvProgress#run
   - Mutant::Runner#run_driver
+  - Mutant::Zombifier::File#self.find
   max_statements: 7
 UncommunicativeMethodName:
   enabled: true
   exclude:
-  - Mutant::Mutation#sha1
   - Mutant::AST::Sexp#s
+  - Mutant::Mutation#sha1
   reject:
   - !ruby/regexp /^[a-z]$/
   - !ruby/regexp /[0-9]$/
@@ -124,15 +124,15 @@ UnusedParameters:
 UtilityFunction:
   enabled: true
   exclude:
-  - Mutant::Actor::Env#new_mailbox
   - Mutant::AST::Sexp#s
+  - Mutant::Actor::Env#new_mailbox
   - Mutant::CLI#reporter
   - Mutant::Integration::Null#call
   - Mutant::Integration::Rspec#parse_example
+  - Mutant::Integration::Rspec#parse_expression # intentional, private
   - Mutant::Meta::Example::Verification#format_mutation
-  - Mutant::Repository::Diff#tracks? # intentional, private
-  - Mutant::Repository::Diff#within_working_directory? # intentional, private
   - Mutant::Reporter::CLI::Format::Progressive#new_buffer
   - Mutant::Reporter::CLI::Printer::StatusProgressive#object # False positive calls super
-  - Mutant::Integration::Rspec#parse_expression # intentional, private
+  - Mutant::Repository::Diff#tracks? # intentional, private
+  - Mutant::Repository::Diff#within_working_directory? # intentional, private
   max_helper_calls: 0

--- a/lib/mutant/matcher/method.rb
+++ b/lib/mutant/matcher/method.rb
@@ -77,12 +77,13 @@ module Mutant
 
       # Path to source
       #
-      # @return [String]
+      # @return [Pathname]
       #
       # @api private
       def source_path
-        source_location.first
+        Pathname.new(source_location.first)
       end
+      memoize :source_path
 
       # Source file line
       #

--- a/lib/mutant/repository.rb
+++ b/lib/mutant/repository.rb
@@ -48,7 +48,7 @@ module Mutant
       #
       # @api private
       def touches?(path, line_range)
-        return false unless tracks?(path)
+        return false unless within_working_directory?(path) && tracks?(path)
 
         command = %W[
           git log
@@ -81,6 +81,18 @@ module Mutant
           out: File::NULL,
           err: File::NULL
         )
+      end
+
+      # Test if the path is within the current working directory
+      #
+      # @param [Pathname] path
+      #
+      # @return [TrueClass, nil]
+      #
+      # @api private
+      def within_working_directory?(path)
+        working_directory = Pathname.pwd
+        path.ascend { |parent| return true if working_directory.eql?(parent) }
       end
 
     end # Diff

--- a/lib/mutant/subject.rb
+++ b/lib/mutant/subject.rb
@@ -21,7 +21,7 @@ module Mutant
 
     # Source path
     #
-    # @return [String]
+    # @return [Pathname]
     #
     # @api private
     def source_path

--- a/lib/mutant/zombifier.rb
+++ b/lib/mutant/zombifier.rb
@@ -114,7 +114,7 @@ module Mutant
 
     # Namespaced root node
     #
-    # @param [Symbol] namespace
+    # @param [Pathname] source_path
     #
     # @return [Parser::AST::Node]
     #

--- a/spec/shared/method_matcher_behavior.rb
+++ b/spec/shared/method_matcher_behavior.rb
@@ -28,6 +28,10 @@ RSpec.shared_examples_for 'a method matcher' do
     expect(context.scope).to eql(scope)
   end
 
+  it 'should have the correct source path in context' do
+    expect(context.source_path).to eql(source_path)
+  end
+
   it 'should have the correct node type' do
     expect(node.type).to be(type)
   end

--- a/spec/support/corpus.rb
+++ b/spec/support/corpus.rb
@@ -3,13 +3,14 @@ require 'anima'
 require 'mutant'
 
 module MutantSpec
+  ROOT = Pathname.new(__FILE__).parent.parent.parent
+
   # Namespace module for corpus testing
   #
   # rubocop:disable MethodLength
   module Corpus
     # Project under corpus test
     # rubocop:disable ClassLength
-    ROOT = Pathname.new(__FILE__).parent.parent.parent
     TMP = ROOT.join('tmp').freeze
 
     class Project

--- a/spec/unit/mutant/matcher/method/instance_spec.rb
+++ b/spec/unit/mutant/matcher/method/instance_spec.rb
@@ -41,38 +41,43 @@ RSpec.describe Mutant::Matcher::Method::Instance do
     end
 
     context 'when method is defined once' do
-      let(:scope)       { base::DefinedOnce }
-      let(:method_line) { 10                }
+      let(:scope)       { base::DefinedOnce                                 }
+      let(:source_path) { MutantSpec::ROOT.join('test_app/lib/test_app.rb') }
+      let(:method_line) { 10                                                }
 
       it_should_behave_like 'a method matcher'
     end
 
     context 'when method is defined once with a memoizer' do
-      let(:scope)       { base::WithMemoizer }
-      let(:method_line) { 15                 }
+      let(:scope)       { base::WithMemoizer                                }
+      let(:source_path) { MutantSpec::ROOT.join('test_app/lib/test_app.rb') }
+      let(:method_line) { 15                                                }
 
       it_should_behave_like 'a method matcher'
     end
 
     context 'when method is defined multiple times' do
       context 'on different lines' do
-        let(:scope)        { base::DefinedMultipleTimes::DifferentLines }
-        let(:method_line)  { 24                                         }
-        let(:method_arity) { 1                                          }
+        let(:scope)        { base::DefinedMultipleTimes::DifferentLines        }
+        let(:source_path)  { MutantSpec::ROOT.join('test_app/lib/test_app.rb') }
+        let(:method_line)  { 24                                                }
+        let(:method_arity) { 1                                                 }
 
         it_should_behave_like 'a method matcher'
       end
 
       context 'on the same line' do
-        let(:scope)        { base::DefinedMultipleTimes::SameLineSameScope }
-        let(:method_line)  { 29                                            }
-        let(:method_arity) { 1                                             }
+        let(:scope)        { base::DefinedMultipleTimes::SameLineSameScope     }
+        let(:source_path)  { MutantSpec::ROOT.join('test_app/lib/test_app.rb') }
+        let(:method_line)  { 29                                                }
+        let(:method_arity) { 1                                                 }
 
         it_should_behave_like 'a method matcher'
       end
 
       context 'on the same line with different scope' do
         let(:scope)        { base::DefinedMultipleTimes::SameLineDifferentScope }
+        let(:source_path)  { MutantSpec::ROOT.join('test_app/lib/test_app.rb')  }
         let(:method_line)  { 33                                                 }
         let(:method_arity) { 1                                                  }
 

--- a/spec/unit/mutant/matcher/method/singleton_spec.rb
+++ b/spec/unit/mutant/matcher/method/singleton_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe Mutant::Matcher::Method::Singleton, '#each' do
   context 'on singleton methods' do
 
     context 'when also defined on lvar' do
-      let(:scope)       { base::AlsoDefinedOnLvar }
-      let(:method_line) { 66                      }
+      let(:scope)       { base::AlsoDefinedOnLvar                           }
+      let(:source_path) { MutantSpec::ROOT.join('test_app/lib/test_app.rb') }
+      let(:method_line) { 66                                                }
 
       it_should_behave_like 'a method matcher'
 
@@ -35,8 +36,9 @@ RSpec.describe Mutant::Matcher::Method::Singleton, '#each' do
     end
 
     context 'when defined on self' do
-      let(:scope)       { base::DefinedOnSelf }
-      let(:method_line) { 61                  }
+      let(:scope)       { base::DefinedOnSelf                               }
+      let(:source_path) { MutantSpec::ROOT.join('test_app/lib/test_app.rb') }
+      let(:method_line) { 61                                                }
 
       it_should_behave_like 'a method matcher'
     end
@@ -44,15 +46,17 @@ RSpec.describe Mutant::Matcher::Method::Singleton, '#each' do
     context 'when defined on constant' do
 
       context 'inside namespace' do
-        let(:scope)       { base::DefinedOnConstant::InsideNamespace }
-        let(:method_line) { 71                                       }
+        let(:scope)       { base::DefinedOnConstant::InsideNamespace          }
+        let(:source_path) { MutantSpec::ROOT.join('test_app/lib/test_app.rb') }
+        let(:method_line) { 71                                                }
 
         it_should_behave_like 'a method matcher'
       end
 
       context 'outside namespace' do
-        let(:method_line) { 78                                        }
-        let(:scope)       { base::DefinedOnConstant::OutsideNamespace }
+        let(:scope)       { base::DefinedOnConstant::OutsideNamespace         }
+        let(:source_path) { MutantSpec::ROOT.join('test_app/lib/test_app.rb') }
+        let(:method_line) { 78                                                }
 
         it_should_behave_like 'a method matcher'
       end
@@ -61,6 +65,7 @@ RSpec.describe Mutant::Matcher::Method::Singleton, '#each' do
     context 'when defined multiple times in the same line' do
       context 'with method on different scope' do
         let(:scope)        { base::DefinedMultipleTimes::SameLine::DifferentScope }
+        let(:source_path)  { MutantSpec::ROOT.join('test_app/lib/test_app.rb')    }
         let(:method_line)  { 97                                                   }
         let(:method_arity) { 1                                                    }
 


### PR DESCRIPTION
This change allows for `--since` to be used in repositories with multiple different projects and only target the code specific to a subdirectory.