### PR TITLE
Mutate args `foo` -> `_foo`

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 18
-total_score: 1193
+total_score: 1189

--- a/lib/mutant/mutator/node/argument.rb
+++ b/lib/mutant/mutator/node/argument.rb
@@ -28,9 +28,7 @@ module Mutant
         # @api private
         def emit_name_mutation
           return if skip?
-          Mutator::Util::Symbol.each(name, self) do |name|
-            emit_name(name)
-          end
+          emit_name(:"#{UNDERSCORE}#{name}")
         end
 
         # Test if argument mutation is skipped

--- a/meta/block.rb
+++ b/meta/block.rb
@@ -20,8 +20,8 @@ Mutant::Meta::Example.add do
   singleton_mutations
   mutation 'foo'
   mutation 'foo { |a, b| raise }'
-  mutation 'foo { |a, b__mutant__| }'
-  mutation 'foo { |a__mutant__, b| }'
+  mutation 'foo { |a, _b| }'
+  mutation 'foo { |_a, b| }'
   mutation 'foo { |a| }'
   mutation 'foo { |b| }'
   mutation 'foo { || }'
@@ -38,9 +38,9 @@ Mutant::Meta::Example.add do
   mutation 'foo { |(b), c| }'
   mutation 'foo { |(a, b)| }'
   mutation 'foo { |c| }'
-  mutation 'foo { |(a__mutant__, b), c| }'
-  mutation 'foo { |(a, b__mutant__), c| }'
-  mutation 'foo { |(a, b), c__mutant__| }'
+  mutation 'foo { |(_a, b), c| }'
+  mutation 'foo { |(a, _b), c| }'
+  mutation 'foo { |(a, b), _c| }'
   mutation 'foo'
 end
 
@@ -66,6 +66,6 @@ Mutant::Meta::Example.add do
   mutation 'foo { || }'
   mutation 'foo { |a| }'
   mutation 'foo { |(a)| raise }'
-  mutation 'foo { |(a__mutant__)| }'
+  mutation 'foo { |(_a)| }'
   mutation 'foo'
 end

--- a/meta/def.rb
+++ b/meta/def.rb
@@ -73,8 +73,8 @@ Mutant::Meta::Example.add do
   mutation 'def foo; end'
 
   # Rename each argument
-  mutation 'def foo(a__mutant__, b); end'
-  mutation 'def foo(a, b__mutant__); end'
+  mutation 'def foo(_a, b); end'
+  mutation 'def foo(a, _b); end'
 
   # Mutation of body
   mutation 'def foo(a, b); raise; end'
@@ -99,8 +99,8 @@ end
 
 Mutant::Meta::Example.add do
   source 'def foo(a = 0, b = 0); end'
-  mutation 'def foo(a = 0, b__mutant__ = 0); end'
-  mutation 'def foo(a__mutant__ = 0, b = 0); end'
+  mutation 'def foo(a = 0, _b = 0); end'
+  mutation 'def foo(_a = 0, b = 0); end'
   mutation 'def foo(a = 0, b = 1); end'
   mutation 'def foo(a = 0, b = -1); end'
   mutation 'def foo(a = 0, b = self); end'
@@ -123,7 +123,7 @@ Mutant::Meta::Example.add do
   mutation 'def foo(); end'
   mutation 'def foo(a = false); end'
   mutation 'def foo(a = nil); end'
-  mutation 'def foo(a__mutant__ = true); end'
+  mutation 'def foo(_a = true); end'
   mutation 'def foo(a = true); raise; end'
 end
 
@@ -158,8 +158,8 @@ Mutant::Meta::Example.add do
   mutation 'def self.foo; end'
 
   # Rename each argument
-  mutation 'def self.foo(a__mutant__, b); end'
-  mutation 'def self.foo(a, b__mutant__); end'
+  mutation 'def self.foo(_a, b); end'
+  mutation 'def self.foo(a, _b); end'
 
   # Mutation of body
   mutation 'def self.foo(a, b); raise; end'


### PR DESCRIPTION
- Changes mutation `foo` -> `_foo` instead of `foo` -> `foo__mutant__`
- closes #292