### PR TITLE
Add a mutation from `a != b` to `!a.eql?(b)` and `!a.equal?(b)`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 * Remove invalid mutation `super(...)` to `super`
 * Add mutation from `def foo(a = true); end` to `def foo(a = true); a = true; end` #419
 * Add mutation from `def foo; end` to `remove_method :foo` #413
+* Add mutation from `a != b` to `!a.eql?(b)` and `!a.equal?(b)` #417
 
 # v0.8.2 2015-08-11
 

--- a/lib/mutant/mutator/node/send/binary.rb
+++ b/lib/mutant/mutator/node/send/binary.rb
@@ -19,7 +19,7 @@ module Mutant
             emit(left)
             emit_left_mutations
             emit_selector_replacement
-            emit(right) unless n_splat?(right)
+            emit(right)
             emit_right_mutations
           end
 

--- a/lib/mutant/mutator/node/send/binary.rb
+++ b/lib/mutant/mutator/node/send/binary.rb
@@ -21,6 +21,30 @@ module Mutant
             emit_selector_replacement
             emit(right)
             emit_right_mutations
+            emit_not_equality_mutations
+          end
+
+          # Emit mutations for `!=`
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def emit_not_equality_mutations
+            return unless operator.equal?(:'!=')
+
+            emit_not_equality_mutation(:eql?)
+            emit_not_equality_mutation(:equal?)
+          end
+
+          # Emit negated method sends with specified operator
+          #
+          # @param new_operator [Symbol] selector to be negated
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def emit_not_equality_mutation(new_operator)
+            emit(n_not(s(:send, left, new_operator, right)))
           end
 
         end # Binary

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -425,7 +425,7 @@ Mutant::Meta::Example.add do
   mutation 'self[*bar]'
 end
 
-(Mutant::AST::Types::BINARY_METHOD_OPERATORS - %i[<= >= < > == eql?]).each do |operator|
+(Mutant::AST::Types::BINARY_METHOD_OPERATORS - %i[<= >= < > == != eql?]).each do |operator|
   Mutant::Meta::Example.add do
     source "true #{operator} false"
 
@@ -437,4 +437,18 @@ end
     mutation "true  #{operator} true"
     mutation "true  #{operator} nil"
   end
+end
+
+Mutant::Meta::Example.add do
+  source 'a != b'
+
+  singleton_mutations
+  mutation 'nil != b'
+  mutation 'self != b'
+  mutation 'a'
+  mutation 'b'
+  mutation 'a != nil'
+  mutation 'a != self'
+  mutation '!a.eql?(b)'
+  mutation '!a.equal?(b)'
 end


### PR DESCRIPTION
Opening a WIP PR for this since I'm not sure how to go about implementing #270 at the moment.  The `mutator/node/send.rb` class seems like an inappropriate place to implement this so I wanted to get some input before I invested time on another implementation