### PR TITLE
Fix mutation to invalid ast on block glueing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,9 @@
 machine:
   ruby:
     version: '2.2'
+dependencies:
+  pre:
+    - bundle -v | grep -Fx "Bundler version 1.10.6" || gem install bundler --version 1.10.6
 test:
   override:
     - bundle exec rake ci

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 18
-total_score: 1234
+total_score: 1233

--- a/lib/mutant/mutator/node/block.rb
+++ b/lib/mutant/mutator/node/block.rb
@@ -49,9 +49,8 @@ module Mutant
           return unless n_send?(body)
 
           body_meta = AST::Meta::Send.new(body)
-          send_meta = AST::Meta::Send.new(send)
 
-          emit(s(:send, send_meta.receiver, body_meta.selector, *body_meta.arguments))
+          emit(s(:send, send, body_meta.selector, *body_meta.arguments))
         end
 
       end # Block

--- a/meta/block.rb
+++ b/meta/block.rb
@@ -71,16 +71,32 @@ Mutant::Meta::Example.add do
 end
 
 Mutant::Meta::Example.add do
-  source 'self.foo { bar(nil) }'
+  source 'foo { bar(nil) }'
 
   singleton_mutations
-  mutation 'self.foo'
-  mutation 'foo { bar(nil) }'
-  mutation 'self.foo { bar }'
-  mutation 'self.foo { nil }'
-  mutation 'self.foo {}'
-  mutation 'self.foo { self }'
-  mutation 'self.foo { raise }'
+  mutation 'foo'
+  mutation 'foo { bar }'
+  mutation 'foo { nil }'
+  mutation 'foo {}'
+  mutation 'foo { self }'
+  mutation 'foo { raise }'
+  mutation 'foo.bar(nil)'
   mutation 'bar(nil)'
-  mutation 'self.bar(nil)'
+end
+
+Mutant::Meta::Example.add do
+  source 'foo { self << true }'
+
+  singleton_mutations
+  mutation 'foo { self << false }'
+  mutation 'foo { self << nil }'
+  mutation 'foo { nil << true }'
+  mutation 'foo { nil }'
+  mutation 'foo { self }'
+  mutation 'foo { true }'
+  mutation 'self << true'
+  mutation 'foo << true'
+  mutation 'foo { raise }'
+  mutation 'foo { }'
+  mutation 'foo'
 end


### PR DESCRIPTION
The mutation operator from #416  was misimplemented. It lifted the inner send to have the receiver of the outer send. Not the outer send AS receiver as intended.

As a byproduct of this fix a related crash to invalid AST was fixed. The exact crash case was NOT included as a spec, because this can only happen on the unwanted mutation.