### PR TITLE
Add mutation from `@foo` to `foo`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 * Add mutation from `Date.parse` to more strict parsing methods #448
 * Add mutation from `foo.to_i` to `Integer(foo)` #455
+* Add mutation from `@foo` to `foo` #454
 
 # v0.8.5 2015-09-11
 

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 18
-total_score: 1244
+total_score: 1253

--- a/lib/mutant/mutator/node/named_value/access.rb
+++ b/lib/mutant/mutator/node/named_value/access.rb
@@ -6,7 +6,7 @@ module Mutant
         # Mutation emitter to handle named value access nodes
         class Access < Node
 
-          handle(:gvar, :cvar, :ivar, :lvar, :self)
+          handle(:gvar, :cvar, :lvar, :self)
 
         private
 
@@ -17,6 +17,45 @@ module Mutant
           # @api private
           def dispatch
             emit_singletons
+          end
+
+          # Named value access emitter for instance variables
+          class Ivar < Access
+            NAME_RANGE = (1..-1).freeze
+
+            handle(:ivar)
+
+            children :name
+
+            # Emit mutations
+            #
+            # @return [undefined]
+            #
+            # @api private
+            def dispatch
+              emit_attribute_read
+              super()
+            end
+
+            private
+
+            # Emit instance variable as attribute send
+            #
+            # @return [undefined]
+            #
+            # @api private
+            def emit_attribute_read
+              emit(s(:send, nil, attribute_name))
+            end
+
+            # Variable name without leading '@'
+            #
+            # @return [Symbol]
+            #
+            # @api private
+            def attribute_name
+              name.slice(NAME_RANGE).to_sym
+            end
           end
 
         end # Access

--- a/meta/ivar.rb
+++ b/meta/ivar.rb
@@ -1,0 +1,6 @@
+Mutant::Meta::Example.add do
+  source '@foo'
+
+  singleton_mutations
+  mutation 'foo'
+end

--- a/meta/op_assgn.rb
+++ b/meta/op_assgn.rb
@@ -2,6 +2,7 @@ Mutant::Meta::Example.add do
   source '@a.b += 1'
 
   singleton_mutations
+  mutation 'a.b += 1'
   mutation '@a.b += -1'
   mutation '@a.b += 2'
   mutation '@a.b += 0'


### PR DESCRIPTION
In the first commit I've reconfigured the AUOM integration to not expect full mutation coverage since this commit adds mutations which AUOM does not cover