### PR TITLE
Correctly exclude evaled code

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v0.8.7 2015-10-30
+
+* Fix blackliting regexp to correctly match the String `(eval)` absolutely.
+
 # v0.8.6. 2015-10-27
 
 * Add mutation from `Date.parse` to more strict parsing methods #448

--- a/lib/mutant/matcher/method.rb
+++ b/lib/mutant/matcher/method.rb
@@ -7,7 +7,7 @@ module Mutant
 
       # Methods within rbx kernel directory are precompiled and their source
       # cannot be accessed via reading source location. Same for methods created by eval.
-      BLACKLIST = %r{\Akernel/|(eval)}.freeze
+      BLACKLIST = %r{\A(kernel/|\(eval\)\z)}.freeze
 
       # Enumerate matches
       #

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -1,4 +1,4 @@
 module Mutant
   # Current mutant version
-  VERSION = '0.8.6'.freeze
+  VERSION = '0.8.7'.freeze
 end # Mutant


### PR DESCRIPTION
* The previous regexp was ment to only match `(eval)` literally.