### PR TITLE
Adds support for dumping JSON formatted summary of execution.

### DIFF
--- a/lib/mutant.rb
+++ b/lib/mutant.rb
@@ -183,6 +183,16 @@ require 'mutant/reporter/cli/printer/status_progressive'
 require 'mutant/reporter/cli/printer/test_result'
 require 'mutant/reporter/cli/tput'
 require 'mutant/reporter/cli/format'
+
+require 'mutant/reporter/hash/printer'
+require 'mutant/reporter/hash/printer/config'
+require 'mutant/reporter/hash/printer/env_result'
+require 'mutant/reporter/hash/printer/env_progress'
+require 'mutant/reporter/hash/printer/mutation_result'
+require 'mutant/reporter/hash/printer/subject_result'
+require 'mutant/reporter/hash/printer/test_result'
+
+
 require 'mutant/repository'
 require 'mutant/zombifier'
 
@@ -201,6 +211,7 @@ module Mutant
       isolation:         Mutant::Isolation::Fork,
       reporter:          Reporter::CLI.build($stdout),
       zombie:            false,
+      json_dump:         false,
       jobs:              Mutant.ci? ? CI_DEFAULT_PROCESSOR_COUNT : ::Parallel.processor_count,
       expected_coverage: Rational(1),
       expression_parser: Expression::Parser.new([

--- a/lib/mutant/cli.rb
+++ b/lib/mutant/cli.rb
@@ -109,6 +109,10 @@ module Mutant
       opts.on('-j', '--jobs NUMBER', 'Number of kill jobs. Defaults to number of processors.') do |number|
         with(jobs: Integer(number))
       end
+
+      opts.on('--json-dump FILENAME', 'Name of file to write JSON output for others to consume.') do |filename|
+        with(json_dump: filename)
+      end
     end
 
     # Use integration

--- a/lib/mutant/config.rb
+++ b/lib/mutant/config.rb
@@ -15,6 +15,7 @@ module Mutant
       :fail_fast,
       :jobs,
       :zombie,
+      :json_dump,
       :expected_coverage,
       :expression_parser
     )

--- a/lib/mutant/reporter/hash/printer.rb
+++ b/lib/mutant/reporter/hash/printer.rb
@@ -1,0 +1,52 @@
+module Mutant
+  class Reporter
+    class Hash
+      # Hash runner status printer base class
+      class Printer
+        include AbstractType, Delegator, Adamantium::Flat, Concord.new(:object), Procto.call(:run)
+
+        private_class_method :new
+
+        delegate :success?
+
+        NL = "\n".freeze
+
+        # Run printer
+        #
+        # @return [self]
+        #
+        # @api private
+        abstract_method :run
+
+      private
+
+        # Visit a collection of objects
+        #
+        # @return [Class::Printer] printer
+        # @return [Enumerable<Object>] collection
+        #
+        # @return [undefined]
+        #
+        # @api private
+        def visit_collection(printer, collection)
+          collection.map do |object|
+            visit(printer, object)
+          end
+        end
+
+        # Visit object
+        #
+        # @param [Class::Printer] printer
+        # @param [Object] object
+        #
+        # @return [undefined]
+        #
+        # @api private
+        def visit(printer, object)
+          printer.call(object)
+        end
+
+      end # Printer
+    end # CLI
+  end # Reporter
+end # Mutant

--- a/lib/mutant/reporter/hash/printer/config.rb
+++ b/lib/mutant/reporter/hash/printer/config.rb
@@ -1,0 +1,36 @@
+module Mutant
+  class Reporter
+    class Hash
+      class Printer
+        # Printer for mutation config
+        class Config < self
+
+          # Report configuration
+          #
+          # @param [Mutant::Config] config
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def run
+            matcher = object.matcher.inspect
+            # #<Mutant::Matcher::Config match_expressions: [Rumble::Loop]>
+            # Parse out expression [...]
+            expression = matcher.scan(/\[([\w:,\*]+)\]/).flatten.first
+            expression ||= matcher
+
+            {
+              matcher: expression,
+              integration: object.integration,
+              expect_coverage: (object.expected_coverage * 100).to_f,
+              jobs: object.jobs,
+              includes: object.includes,
+              requires: object.requires
+            }
+          end
+
+        end # Config
+      end # Printer
+    end # CLI
+  end # Reporter
+end # Mutant

--- a/lib/mutant/reporter/hash/printer/env_progress.rb
+++ b/lib/mutant/reporter/hash/printer/env_progress.rb
@@ -1,0 +1,64 @@
+module Mutant
+  class Reporter
+    class Hash
+      class Printer
+        # Env progress printer
+        class EnvProgress < self
+          delegate(
+            :coverage,
+            :amount_subjects,
+            :amount_mutations,
+            :amount_mutations_alive,
+            :amount_mutations_killed,
+            :runtime,
+            :killtime,
+            :overhead,
+            :env
+          )
+
+          # Run printer
+          #
+          # @return [undefined]
+          #
+          # rubocop:disable AbcSize
+          #
+          # @api private
+          def run
+            {
+              config: visit(Config, env.config),
+              subjects: amount_subjects,
+              mutations: amount_mutations,
+              kills: amount_mutations_killed,
+              alive: amount_mutations_alive,
+              runtime: runtime,
+              killtime: killtime,
+              overhead: overhead_percent.to_f,
+              coverage: coverage_percent.to_f,
+              expected: (env.config.expected_coverage * 100).to_f
+            }
+          end
+
+        private
+
+          # Coverage in percent
+          #
+          # @return [Float]
+          #
+          # @api private
+          def coverage_percent
+            coverage * 100
+          end
+
+          # Overhead in percent
+          #
+          # @return [Float]
+          #
+          # @api private
+          def overhead_percent
+            (overhead / killtime) * 100
+          end
+        end # EnvProgress
+      end # Printer
+    end # CLI
+  end # Reporter
+end # Mutant

--- a/lib/mutant/reporter/hash/printer/env_result.rb
+++ b/lib/mutant/reporter/hash/printer/env_result.rb
@@ -1,0 +1,26 @@
+module Mutant
+  class Reporter
+    class Hash
+      class Printer
+        # Full env result reporter
+        class EnvResult < self
+          delegate(:failed_subject_results)
+          delegate(:subject_results)
+
+          # Run printer
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def run
+            {
+              failed_subject_results: visit_collection(SubjectResult, failed_subject_results),
+              success_subject_results: visit_collection(SubjectResult, subject_results.select(&:success?)),
+              env_progress: visit(EnvProgress, object)
+            }
+          end
+        end # EnvResult
+      end # Printer
+    end # Hash
+  end # Reporter
+end # Mutant

--- a/lib/mutant/reporter/hash/printer/mutation_result.rb
+++ b/lib/mutant/reporter/hash/printer/mutation_result.rb
@@ -1,0 +1,149 @@
+module Mutant
+  class Reporter
+    class Hash
+      class Printer
+        # Reporter for mutation results
+        class MutationResult < self
+
+          delegate :mutation, :test_result
+
+          DIFF_ERROR_MESSAGE =
+            'BUG: Mutation NOT resulted in exactly one diff hunk. Please report a reproduction!'.freeze
+
+          MAP = {
+            Mutant::Mutation::Evil    => :evil_details,
+            Mutant::Mutation::Neutral => :neutral_details,
+            Mutant::Mutation::Noop    => :noop_details
+          }.freeze
+
+          NEUTRAL_MESSAGE =
+            "--- Neutral failure ---\n" \
+            "Original code was inserted unmutated. And the test did NOT PASS.\n" \
+            "Your tests do not pass initially or you found a bug in mutant / unparser.\n" \
+            "Subject AST:\n" \
+            "%s\n" \
+            "Unparsed Source:\n" \
+            "%s\n" \
+            "Test Result:\n".freeze
+
+          NO_DIFF_MESSAGE =
+            "--- Internal failure ---\n" \
+            "BUG: Mutation NOT resulted in exactly one diff hunk. Please report a reproduction!\n" \
+            "Original unparsed source:\n" \
+            "%s\n" \
+            "Original AST:\n" \
+            "%s\n" \
+            "Mutated unparsed source:\n" \
+            "%s\n" \
+            "Mutated AST:\n" \
+            "%s\n".freeze
+
+          NOOP_MESSAGE    =
+            "---- Noop failure -----\n" \
+            "No code was inserted. And the test did NOT PASS.\n" \
+            "This is typically a problem of your specs not passing unmutated.\n" \
+            "Test Result:\n".freeze
+
+          FOOTER = '-----------------------'.freeze
+
+          # Run report printer
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def run
+            {
+              identification: mutation.identification,
+              details: print_details
+            }
+          end
+
+        private
+
+          # Print mutation details
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def print_details
+            __send__(MAP.fetch(mutation.class))
+          end
+
+          # Evil mutation details
+          #
+          # @return [String]
+          #
+          # @api private
+          def evil_details
+            diff = Diff.build(mutation.original_source, mutation.source)
+            diff = false ? diff.colorized_diff : diff.diff
+            if diff
+              diff
+            else
+              print_no_diff_message
+            end
+          end
+
+          # Print no diff message
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def print_no_diff_message
+            NO_DIFF_MESSAGE % [
+                mutation.original_source,
+                original_node.inspect,
+                mutation.source,
+                mutation.node.inspect
+              ]
+          end
+
+          # Noop details
+          #
+          # @return [String]
+          #
+          # @api private
+          def noop_details
+            {
+              type: 'noop',
+              message: NOOP_MESSAGE,
+              result: visit_test_result
+            }
+          end
+
+          # Neutral details
+          #
+          # @return [String]
+          #
+          # @api private
+          def neutral_details
+            {
+              type: 'neutral',
+              message: NEUTRAL_MESSAGE % [original_node.inspect, mutation.source],
+              result: visit_test_result
+            }
+          end
+
+          # Visit failed test results
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def visit_test_result
+            visit(TestResult, test_result)
+          end
+
+          # Original node
+          #
+          # @return [Parser::AST::Node]
+          #
+          # @api private
+          def original_node
+            mutation.subject.node
+          end
+
+        end # MutationResult
+      end # Printer
+    end # CLI
+  end # Reporter
+end # Mutant

--- a/lib/mutant/reporter/hash/printer/subject_result.rb
+++ b/lib/mutant/reporter/hash/printer/subject_result.rb
@@ -1,0 +1,27 @@
+module Mutant
+  class Reporter
+    class Hash
+      class Printer
+        # Subject result printer
+        class SubjectResult < self
+
+          delegate :subject, :alive_mutation_results, :tests
+
+          # Run report printer
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def run
+            {
+              identification: subject.identification,
+              tests: tests.map(&:identification),
+              mutation_result: visit_collection(MutationResult, alive_mutation_results)
+            }
+          end
+
+        end # SubjectResult
+      end # Printer
+    end # CLI
+  end # Reporter
+end # Mutant

--- a/lib/mutant/reporter/hash/printer/test_result.rb
+++ b/lib/mutant/reporter/hash/printer/test_result.rb
@@ -1,0 +1,28 @@
+module Mutant
+  class Reporter
+    class Hash
+      class Printer
+        # Test result reporter
+        class TestResult < self
+
+          delegate :tests, :runtime
+
+          # Run test result reporter
+          #
+          # @return [undefined]
+          #
+          # @api private
+          def run
+            {
+              count: tests.length,
+              runtime: runtime,
+              tests: tests.map(&:identification),
+              output: object.output
+            }
+          end
+
+        end # TestResult
+      end # Printer
+    end # CLI
+  end # Reporter
+end # Mutant

--- a/lib/mutant/runner.rb
+++ b/lib/mutant/runner.rb
@@ -33,6 +33,12 @@ module Mutant
     def run_mutation_analysis
       @result = run_driver(Parallel.async(mutation_test_config))
       reporter.report(@result)
+
+      if env.config.json_dump
+        require 'json'
+        hash = Reporter::Hash::Printer::EnvResult.call(@result)
+        File.open(env.config.json_dump, 'w') {|f| f.write(hash.to_json) }
+      end
     end
 
     # Run driver


### PR DESCRIPTION
We participated in Rails Rumble over the weekend and built a product based on your mutant gem.  Instead of parsing standard out I implemented a printer for collecting results into a hash and then dumping them to a file as JSON format.  Hopefully this is useful for you and others using the tool.  I'm happy to make any changes you suggest.  I did not write any tests for this, is that something you would like?

I also realize there's a bit of duplication between the CLI printer. If you have ways to consolidate that I'm open to it. 