### PR TITLE
Drop support for rspec-3.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v0.8.8 2015-xx-xx
+
+* Drop support for rspec-3.2
+
 # v0.8.8 2015-11-15
 
 * Add support for rspec-3.3.4

--- a/mutant-rspec.gemspec
+++ b/mutant-rspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[TODO LICENSE]
 
   gem.add_runtime_dependency('mutant', "~> #{gem.version}")
-  gem.add_runtime_dependency('rspec-core', '>= 3.2.0', '< 3.5.0')
+  gem.add_runtime_dependency('rspec-core', '>= 3.3.0', '< 3.5.0')
 
   gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
 end

--- a/spec/integration/mutant/rspec_spec.rb
+++ b/spec/integration/mutant/rspec_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'rspec integration', mutant: false do
 
   let(:base_cmd) { 'bundle exec mutant -I lib --require test_app --use rspec' }
 
-  %w[3.2 3.3 3.4].each do |version|
+  %w[3.3 3.4].each do |version|
     context "RSpec #{version}" do
       let(:gemfile) { "Gemfile.rspec#{version}" }
 

--- a/test_app/Gemfile.rspec3.2
+++ b/test_app/Gemfile.rspec3.2
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-gem 'rspec',      '~> 3.2.0'
-gem 'rspec-core', '~> 3.2.0'
-gem 'mutant',       path: '../'
-gem 'mutant-rspec', path: '../'
-gem 'adamantium'
-eval_gemfile File.expand_path('../../Gemfile.shared', __FILE__)


### PR DESCRIPTION
I do not like to carry around supports for things I do not use by myself. And enlarge CI runtime for no real gain. Updating rspec is trivial.