### PR TITLE
Kill mutations in Mutant::Runner

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 18
-total_score: 1226
+total_score: 1227

--- a/lib/mutant/runner.rb
+++ b/lib/mutant/runner.rb
@@ -32,7 +32,7 @@ module Mutant
     # @api private
     def run_mutation_analysis
       @result = run_driver(Parallel.async(mutation_test_config))
-      reporter.report(@result)
+      reporter.report(result)
     end
 
     # Run driver
@@ -68,7 +68,7 @@ module Mutant
         env:       env.actor_env,
         jobs:      config.jobs,
         source:    Parallel::Source::Array.new(env.mutations),
-        sink:      Sink::Mutation.new(env),
+        sink:      Sink.new(env),
         processor: env.method(:kill)
       )
     end

--- a/lib/mutant/runner/sink.rb
+++ b/lib/mutant/runner/sink.rb
@@ -1,107 +1,72 @@
 module Mutant
   class Runner
-    # Abstract base class for computation sinks
     class Sink
-      include AbstractType
+      include Concord.new(:env)
 
-      # sink status
+      # Initialize object
       #
-      # @return [Object]
+      # @return [undefined]
       #
       # @api private
-      abstract_method :status
+      def initialize(*)
+        super
+        @start           = Time.now
+        @subject_results = {}
+      end
 
-      # Test if computation should be stopped
+      # Runner status
+      #
+      # @return [Result::Env]
+      #
+      # @api private
+      def status
+        Result::Env.new(
+          env:             env,
+          runtime:         Time.now - @start,
+          subject_results: @subject_results.values
+        )
+      end
+
+      # Test if scheduling stopped
       #
       # @return [Boolean]
       #
       # @api private
-      abstract_method :stop?
+      def stop?
+        env.config.fail_fast && !status.subject_results.all?(&:success?)
+      end
 
-      # Consume result
+      # Handle mutation finish
       #
-      # @param [Object] result
+      # @param [Result::Mutation] mutation_result
       #
       # @return [self]
       #
       # @api private
-      abstract_method :result
+      def result(mutation_result)
+        subject = mutation_result.mutation.subject
 
-      # Mutation result sink
-      class Mutation < self
-        include Concord.new(:env)
+        @subject_results[subject] = Result::Subject.new(
+          subject:          subject,
+          mutation_results: previous_mutation_results(subject) + [mutation_result],
+          tests:            mutation_result.test_result.tests
+        )
 
-        # Initialize object
-        #
-        # @return [undefined]
-        #
-        # @api private
-        def initialize(*)
-          super
-          @start           = Time.now
-          @subject_results = Hash.new do |_hash, subject|
-            Result::Subject.new(
-              subject:          subject,
-              tests:            [],
-              mutation_results: []
-            )
-          end
-        end
+        self
+      end
 
-        # Runner status
-        #
-        # @return [Status]
-        #
-        # @api private
-        def status
-          env_result
-        end
+    private
 
-        # Test if scheduling stopped
-        #
-        # @return [Boolean]
-        #
-        # @api private
-        def stop?
-          env.config.fail_fast && !env_result.subject_results.all?(&:success?)
-        end
+      # Return previous results
+      #
+      # @param [Subject]
+      #
+      # @return [Array<Result::Mutation>]
+      def previous_mutation_results(subject)
+        subject_result = @subject_results.fetch(subject) { return EMPTY_ARRAY }
+        subject_result.mutation_results
+      end
 
-        # Handle mutation finish
-        #
-        # @param [Result::Mutation] mutation_result
-        #
-        # @return [self]
-        #
-        # @api private
-        def result(mutation_result)
-          mutation = mutation_result.mutation
-
-          original = @subject_results[mutation.subject]
-
-          @subject_results[mutation.subject] = original.with(
-            mutation_results: (original.mutation_results + [mutation_result]),
-            tests:            mutation_result.test_result.tests
-          )
-
-          self
-        end
-
-      private
-
-        # Current result
-        #
-        # @return [Result::Env]
-        #
-        # @api private
-        def env_result
-          Result::Env.new(
-            env:             env,
-            runtime:         Time.now - @start,
-            subject_results: @subject_results.values
-          )
-        end
-
-      end # Mutation
     end # Sink
   end # Runner
 end # Mutant

--- a/spec/unit/mutant/runner/sink_spec.rb
+++ b/spec/unit/mutant/runner/sink_spec.rb
@@ -1,4 +1,4 @@
-describe Mutant::Runner::Sink::Mutation do
+describe Mutant::Runner::Sink do
   setup_shared_context
 
   shared_context 'one result' do

--- a/spec/unit/mutant/runner_spec.rb
+++ b/spec/unit/mutant/runner_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Mutant::Runner do
         jobs:      1,
         env:       actor_env,
         source:    Mutant::Parallel::Source::Array.new(env.mutations),
-        sink:      Mutant::Runner::Sink::Mutation.new(env),
+        sink:      Mutant::Runner::Sink.new(env),
         processor: env.method(:kill)
       )
     end


### PR DESCRIPTION
* Prefer attribute reader over ivar
* Reduce intermediary unused abstract class
* Do not build a Mutant::Result::Subject in Hash default
  where an empty mutation result Array is sufficient.