### PR TITLE
Fix/setup error handling

### DIFF
--- a/lib/mutant/integration/rspec.rb
+++ b/lib/mutant/integration/rspec.rb
@@ -65,8 +65,15 @@ module Mutant
         Result::Test.new(
           output:   @output.read,
           passed:   passed,
-          runtime:  Time.now - start,
+          runtime:  calculate_run_time(start),
           tests:    tests
+        )
+      rescue => exception
+        Result::Test.new(
+            tests:    tests,
+            output:   exception.to_s,
+            runtime:  calculate_run_time(start),
+            passed:   false
         )
       end
 
@@ -142,6 +149,21 @@ module Mutant
       def filter_examples(&predicate)
         @world.filtered_examples.each_value do |examples|
           examples.keep_if(&predicate)
+        end
+      end
+
+      # Calculate the run time of a test
+      #
+      # @param [#Time] start_time
+      #
+      # @return [Time]
+      #
+      # @api private
+      def calculate_run_time(start_time)
+        if start_time
+          Time.now - start_time
+        else
+          Time.at(0)
         end
       end
 

--- a/lib/mutant/isolation.rb
+++ b/lib/mutant/isolation.rb
@@ -47,7 +47,11 @@ module Mutant
             end
 
             writer.close
-            Marshal.load(reader.read)
+            data = reader.read
+            if data.nil? || data.empty?
+              raise Error.new('Mutation returned no data!')
+            end
+            Marshal.load(data)
           ensure
             Process.waitpid(pid) if pid
           end

--- a/spec/unit/mutant/isolation_spec.rb
+++ b/spec/unit/mutant/isolation_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Mutant::Isolation::Fork do
     end
 
     it 'wraps exceptions' do
-      expect { object.call { fail } }.to raise_error(Mutant::Isolation::Error, 'marshal data too short')
+      expect { object.call { fail } }.to raise_error(Mutant::Isolation::Error, 'Mutation returned no data!')
     end
 
     it 'wraps exceptions caused by crashing ruby' do


### PR DESCRIPTION
I ran into a problem using mutant to test my rails application that uses SQLite as the DB. The mutant workers were fighting over the test DB and getting "SQLite3::ReadOnlyException: attempt to write a readonly database" exceptions. It took me a LONG time to figure out why the tests were failing because the SQLite exception was being eaten and a marshaling error, "marshal data too short" was being displayed instead. If you would like to reproduce the problem behavior, you may do so by running "bundle exec mutant -I ./lib/git --use rspec Git::GitBranch" on this repo: https://github.com/mikeweaver/git-conflict-detector

This pull request is a proposed fix for handling errors that occur during the setup inside mutant before running the actual test. It will cause the actual error that occurred to be shown to the user. If you agree with the fix, I will write some unit tests for it.

One concern I have: With this fix it won't be possible for mutant to differentiate between tests that failed because they were supposed to and tests that failed during mutant setup. Perhaps we should add a param to TestResult that could be use to differentiate these two cases?