### PR TITLE
Bubble exceptions in isolation up to parent process

### DIFF
--- a/lib/mutant/env.rb
+++ b/lib/mutant/env.rb
@@ -44,8 +44,12 @@ module Mutant
       tests = selector.call(mutation.subject)
 
       config.isolation.call do
-        mutation.insert(config.kernel)
-        integration.call(tests)
+        begin
+          mutation.insert(config.kernel)
+          integration.call(tests)
+        rescue => exception
+          exception.to_s
+        end
       end
     rescue Isolation::Error => error
       Result::Test.new(

--- a/lib/mutant/isolation.rb
+++ b/lib/mutant/isolation.rb
@@ -47,11 +47,18 @@ module Mutant
             end
 
             writer.close
-            Marshal.load(reader.read)
+            result = Marshal.load(reader.read)
+            if result.is_a?(Mutant::Result::Test)
+              result
+            else
+              raise Error, result.to_s
+            end
           ensure
             Process.waitpid(pid) if pid
           end
         end
+      rescue Error => exception
+        raise exception
       rescue => exception
         raise Error, exception
       end


### PR DESCRIPTION
If an exception is raised during the setup or tear down for the mutant it will cause the block to return no data. This causes Marshal.load to fail with a vague error message: "marshal data too short".

Instead, the block should catch the exception and return a stringified version. Then the isolation can raise an exception with the string.