### PR TITLE
update README limitations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,48 +62,49 @@ Limitations
 
 Mutant cannot emit mutations for...
 
-* methods defined within a closure.  For example, methods defined using `module_eval`, `class_eval`,
-  `define_method`, or `define_singleton_method`:
+* methods defined within a closure in 3rd party code. For example, methods defined using `module_eval`, `class_eval`, `define_method`, or `define_singleton_method`:
 
-    ```ruby
-    class Example
-      class_eval do
-        def example1
-        end
-      end
+  ```ruby
+  class Example
+    include MonkeyPatchyDSL # cannot mutate included code
 
-      module_eval do
-        def example2
-        end
-      end
-
-      define_method(:example3) do
-      end
-
-      define_singleton_method(:example4) do
+    class_eval do
+      def example1 # ok
       end
     end
-    ```
+
+    module_eval do
+      def example2 # ok
+      end
+    end
+
+    define_method(:example3) do # ok
+    end
+
+    define_singleton_method(:example4) do # ok
+    end
+  end
+  ```
 
 * singleton methods not defined on a constant or `self`
 
-    ```ruby
-    class Foo
-      def self.bar; end   # ok
-      def Foo.baz; end    # ok
+  ```ruby
+  class Foo
+    def self.bar; end   # ok
+    def Foo.baz; end    # ok
 
-      myself = self
-      def myself.qux; end # cannot mutate
-    end
-    ```
+    myself = self
+    def myself.qux; end # cannot mutate
+  end
+  ```
 
 * methods defined with eval:
 
-    ```ruby
-    class Foo
-      class_eval('def bar; end') # cannot mutate
-    end
-    ```
+  ```ruby
+  class Foo
+    class_eval('def bar; end') # cannot mutate
+  end
+  ```
 
 Mutation-Operators
 ------------------
@@ -203,12 +204,12 @@ Mutation output is grouped by selection groups. Each group contains three sectio
     end
    -----------------------
    ```
-   
+
 Concurrency
 -----------
 
 By default, mutant will test mutations in parallel by running up to one process for each core on your system. You can control the number of processes created using the `--jobs` argument.
- 
+
 Mutant forks a new process for each mutation to be tested to prevent side affects in your specs, and the lack of thread safety in rspec, from impacting the results.
 
 If the code under test relies on a database, you may experience problems when running mutant because of conflicting data in the database. For example, if you have a test like this:


### PR DESCRIPTION
@mbj Please make sure the updates I made are correct and clear. Also please let me know if you think a more explicit example / rewording would be better.

Small tweaks:
- Changed indentation level on code blocks in limitations section.
  - Rendered fine on GitHub, but looked funky on other Markdown renderers (Atom), now fine on both.
- Atom trimmed some trailing whitespace.