### PR TITLE
Add keword arument mutations

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 16
-total_score: 1160
+total_score: 1166

--- a/lib/mutant/mutator/node/argument.rb
+++ b/lib/mutant/mutator/node/argument.rb
@@ -4,7 +4,7 @@ module Mutant
 
       # Mutator for required arguments
       class Argument < self
-        handle(:arg)
+        handle(:arg, :kwarg)
 
         UNDERSCORE = '_'.freeze
 

--- a/lib/mutant/mutator/node/argument.rb
+++ b/lib/mutant/mutator/node/argument.rb
@@ -37,7 +37,12 @@ module Mutant
         # Mutator for optional arguments
         class Optional < self
 
-          handle(:optarg)
+          TYPE_MAP = IceNine.deep_freeze(
+            optarg:   :arg,
+            kwoptarg: :kwarg
+          )
+
+          handle(:optarg, :kwoptarg)
 
           children :name, :default
 
@@ -56,7 +61,7 @@ module Mutant
           #
           # @return [undefined]
           def emit_required_mutation
-            emit(s(:arg, name))
+            emit(s(TYPE_MAP.fetch(node.type), name))
           end
 
         end # Optional

--- a/lib/mutant/mutator/node/generic.rb
+++ b/lib/mutant/mutator/node/generic.rb
@@ -9,7 +9,7 @@ module Mutant
         # your contribution is that close!
         handle(
           :ensure, :redo, :regopt, :retry, :arg_expr, :blockarg,
-          :kwrestarg, :kwoptarg, :undef, :module, :empty,
+          :kwrestarg, :undef, :module, :empty,
           :alias, :for, :xstr, :back_ref, :class, :restarg,
           :sclass, :match_with_lvasgn, :while_post,
           :until_post, :preexe, :postexe, :iflipflop, :eflipflop, :kwsplat,

--- a/lib/mutant/mutator/node/generic.rb
+++ b/lib/mutant/mutator/node/generic.rb
@@ -9,7 +9,7 @@ module Mutant
         # your contribution is that close!
         handle(
           :ensure, :redo, :regopt, :retry, :arg_expr, :blockarg,
-          :kwrestarg, :kwoptarg, :kwarg, :undef, :module, :empty,
+          :kwrestarg, :kwoptarg, :undef, :module, :empty,
           :alias, :for, :xstr, :back_ref, :class, :restarg,
           :sclass, :match_with_lvasgn, :while_post,
           :until_post, :preexe, :postexe, :iflipflop, :eflipflop, :kwsplat,

--- a/meta/kwarg.rb
+++ b/meta/kwarg.rb
@@ -1,0 +1,7 @@
+Mutant::Meta::Example.add :kwarg do
+  source 'def foo(bar:); end'
+
+  mutation 'def foo; end'
+  mutation 'def foo(bar:); raise; end'
+  mutation 'remove_method(:foo)'
+end

--- a/meta/kwarg.rb
+++ b/meta/kwarg.rb
@@ -4,4 +4,5 @@ Mutant::Meta::Example.add :kwarg do
   mutation 'def foo; end'
   mutation 'def foo(bar:); raise; end'
   mutation 'remove_method(:foo)'
+  mutation 'def foo(_bar:); end'
 end

--- a/meta/kwoptarg.rb
+++ b/meta/kwoptarg.rb
@@ -1,0 +1,9 @@
+Mutant::Meta::Example.add :kwoptarg do
+  source 'def foo(bar: baz); end'
+
+  mutation 'def foo; end'
+  mutation 'def foo(bar: baz); raise; end'
+  mutation 'remove_method(:foo)'
+  mutation 'def foo(bar: nil); end'
+  mutation 'def foo(bar: self); end'
+end

--- a/meta/kwoptarg.rb
+++ b/meta/kwoptarg.rb
@@ -1,4 +1,4 @@
-Mutant::Meta::Example.add :kwoptarg do
+Mutant::Meta::Example.add :kwarg do
   source 'def foo(bar: baz); end'
 
   mutation 'def foo; end'
@@ -6,4 +6,6 @@ Mutant::Meta::Example.add :kwoptarg do
   mutation 'remove_method(:foo)'
   mutation 'def foo(bar: nil); end'
   mutation 'def foo(bar: self); end'
+  mutation 'def foo(bar:); end'
+  mutation 'def foo(_bar: baz); end'
 end


### PR DESCRIPTION
Adds mutations for keword arguments (closing #291):

| Source                   | Mutation                  |
| :---------------------   | :---------------------    |
| `def foo(bar:); end`     | `def foo(_bar:); end`     |
| `def foo(bar: baz); end` | `def foo(_bar: baz); end` |
| `def foo(bar: baz); end` | `def foo(bar:); end`      |
