### PR TITLE
Fix regexp_parser syntax for ruby 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 gemspec name: 'mutant'
 
 eval_gemfile File.expand_path('../Gemfile.shared', __FILE__)
+
+gem 'regexp_parser', git: 'https://github.com/backus/regexp_parser', branch: 'preview'

--- a/lib/mutant/ast/regexp.rb
+++ b/lib/mutant/ast/regexp.rb
@@ -3,7 +3,20 @@ module Mutant
     # Regexp source mapper
     module Regexp
       UNSUPPORTED_EXPRESSION_TYPE = :conditional
+
       private_constant(*constants(false))
+
+      # Parse regex string into expression
+      #
+      # @param regexp [String]
+      #
+      # @return [Regexp::Expression]
+      def self.parse(regexp)
+        ::Regexp::Parser.parse(
+          regexp,
+          "ruby/#{RUBY_VERSION.split('.').first(2).join('.')}"
+        )
+      end
 
       # Check if expression is supported by mapper
       #

--- a/lib/mutant/ast/regexp/transformer/direct.rb
+++ b/lib/mutant/ast/regexp/transformer/direct.rb
@@ -73,6 +73,8 @@ module Mutant
               [:regexp_digit_type,               [:type,     :digit,            '\d'],           ::Regexp::Expression::CharacterType::Digit],
               [:regexp_space_type,               [:type,     :space,            '\s'],           ::Regexp::Expression::CharacterType::Space],
               [:regexp_word_type,                [:type,     :word,             '\w'],           ::Regexp::Expression::CharacterType::Word],
+              [:regexp_hex_type,                 [:type,     :hex,              '\h'],           ::Regexp::Expression::CharacterType::Hex],
+              [:regexp_nonhex_type,              [:type,     :nonhex,           '\H'],           ::Regexp::Expression::CharacterType::NonHex],
               [:regexp_nondigit_type,            [:type,     :nondigit,         '\D'],           ::Regexp::Expression::CharacterType::NonDigit],
               [:regexp_nonspace_type,            [:type,     :nonspace,         '\S'],           ::Regexp::Expression::CharacterType::NonSpace],
               [:regexp_nonword_type,             [:type,     :nonword,          '\W'],           ::Regexp::Expression::CharacterType::NonWord],

--- a/lib/mutant/ast/types.rb
+++ b/lib/mutant/ast/types.rb
@@ -72,6 +72,7 @@ module Mutant
         regexp_group_close_escape
         regexp_group_open_escape
         regexp_hex_escape
+        regexp_hex_type
         regexp_interval_close_escape
         regexp_interval_open_escape
         regexp_letter_any_property
@@ -91,6 +92,7 @@ module Mutant
         regexp_nonspace_type
         regexp_nonword_boundary_anchor
         regexp_nonword_type
+        regexp_nonhex_type
         regexp_number_backref
         regexp_one_or_more_escape
         regexp_open_conditional

--- a/lib/mutant/mutator/node/literal/regex.rb
+++ b/lib/mutant/mutator/node/literal/regex.rb
@@ -60,7 +60,7 @@ module Mutant
           #
           # @return [Regexp::Expression]
           def body_expression
-            ::Regexp::Parser.parse(body.map(&:children).join)
+            AST::Regexp.parse(body.map(&:children).join)
           end
           memoize :body_expression
 

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('equalizer',     '~> 0.0.9')
   gem.add_runtime_dependency('anima',         '~> 0.3.0')
   gem.add_runtime_dependency('concord',       '~> 0.1.5')
-  gem.add_runtime_dependency('regexp_parser', '~> 0.3.3')
+  gem.add_runtime_dependency('regexp_parser', '=  0.3.3')
 
   gem.add_development_dependency('devtools', '~> 0.1.4')
   gem.add_development_dependency('bundler',  '~> 1.10')

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('equalizer',     '~> 0.0.9')
   gem.add_runtime_dependency('anima',         '~> 0.3.0')
   gem.add_runtime_dependency('concord',       '~> 0.1.5')
-  gem.add_runtime_dependency('regexp_parser', '=  0.3.3')
+  gem.add_runtime_dependency('regexp_parser', '~> 0.3.5')
 
   gem.add_development_dependency('devtools', '~> 0.1.4')
   gem.add_development_dependency('bundler',  '~> 1.10')

--- a/spec/unit/mutant/ast/regexp/parse_spec.rb
+++ b/spec/unit/mutant/ast/regexp/parse_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe Mutant::AST::Regexp, '.parse' do
+  before { stub_const('RUBY_VERSION', '2.3.9') }
+
+  it 'parses using minor ruby version' do
+    expect(described_class.parse(/foo/).to_re).to eql(/foo/)
+  end
+end

--- a/spec/unit/mutant/ast/regexp/supported_predicate_spec.rb
+++ b/spec/unit/mutant/ast/regexp/supported_predicate_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Mutant::AST::Regexp, '.supported?' do
   subject { described_class.supported?(expression) }
 
-  let(:expression) { Regexp::Parser.parse(regexp) }
-  let(:regexp)     { /foo/                        }
+  let(:expression) { described_class.parse(regexp) }
+  let(:regexp)     { /foo/                         }
 
   it { should be(true) }
 

--- a/spec/unit/mutant/ast/regexp_spec.rb
+++ b/spec/unit/mutant/ast/regexp_spec.rb
@@ -339,6 +339,16 @@ RegexpSpec.expect_mapping(/\xFF/n, :regexp_hex_escape) do
     s(:regexp_hex_escape, '\\xFF'))
 end
 
+RegexpSpec.expect_mapping(/\h/, :regexp_hex_type) do
+  s(:regexp_root_expression,
+    s(:regexp_hex_type))
+end
+
+RegexpSpec.expect_mapping(/\H/, :regexp_hex_type) do
+  s(:regexp_root_expression,
+    s(:regexp_nonhex_type))
+end
+
 RegexpSpec.expect_mapping(/\}/, :regexp_interval_close_escape) do
   s(:regexp_root_expression,
     s(:regexp_interval_close_escape))

--- a/spec/unit/mutant/ast/regexp_spec.rb
+++ b/spec/unit/mutant/ast/regexp_spec.rb
@@ -24,7 +24,7 @@ module RegexpSpec
   end # Expression
 
   RSpec.shared_context 'regexp transformation' do
-    let(:parsed)     { Regexp::Parser.parse(regexp)           }
+    let(:parsed)     { Mutant::AST::Regexp.parse(regexp)      }
     let(:ast)        { Mutant::AST::Regexp.to_ast(parsed)     }
     let(:expression) { Mutant::AST::Regexp.to_expression(ast) }
 


### PR DESCRIPTION
I'm interested in adding to regexp_parser for a more robust solution. See https://github.com/ammar/regexp_parser/issues/23
