### PR TITLE
Fix range mutations

### DIFF
--- a/lib/mutant/mutator/node/literal/range.rb
+++ b/lib/mutant/mutator/node/literal/range.rb
@@ -11,7 +11,7 @@ module Mutant
             erange: :irange
           }.freeze
 
-          children :start, :_end
+          children :lower_bound, :upper_bound
 
           handle(*MAP.keys)
 
@@ -32,23 +32,6 @@ module Mutant
           # @return [Parser::AST::Node]
           def emit_inverse
             emit(s(MAP.fetch(node.type), *children))
-          end
-
-          # Emit range start mutations
-          #
-          # @return [undefined]
-          def emit_upper_bound_mutations
-            emit__end_mutations
-            emit_type(N_NAN, _end)
-          end
-
-          # Emit start mutations
-          #
-          # @return [undefined]
-          def emit_lower_bound_mutations
-            emit_start_mutations
-            emit_type(start, N_INFINITY)
-            emit_type(start, N_NAN)
           end
 
         end # Range

--- a/meta/range.rb
+++ b/meta/range.rb
@@ -3,9 +3,6 @@ Mutant::Meta::Example.add :irange do
 
   singleton_mutations
   mutation '1...100'
-  mutation '(0.0 / 0.0)..100'
-  mutation '1..(1.0 / 0.0)'
-  mutation '1..(0.0 / 0.0)'
   mutation '-1..100'
   mutation '0..100'
   mutation '2..100'
@@ -25,9 +22,6 @@ Mutant::Meta::Example.add :erange do
 
   singleton_mutations
   mutation '1..100'
-  mutation '(0.0 / 0.0)...100'
-  mutation '1...(1.0 / 0.0)'
-  mutation '1...(0.0 / 0.0)'
   mutation '-1...100'
   mutation '0...100'
   mutation '2...100'

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -509,14 +509,11 @@ Mutant::Meta::Example.add :send do
   mutation 'foo(n...-1)'
   mutation 'foo(nil..-1)'
   mutation 'foo(self..-1)'
-  mutation 'foo(n..(1.0 / 0.0))'
-  mutation 'foo(n..(0.0 / 0.0))'
   mutation 'foo(n..nil)'
   mutation 'foo(n..self)'
   mutation 'foo(n..0)'
   mutation 'foo(n..1)'
   mutation 'foo(n..-2)'
-  mutation 'foo((0.0 / 0.0)..-1)'
 end
 
 Mutant::Meta::Example.add :send do
@@ -542,9 +539,6 @@ Mutant::Meta::Example.add :send do
   mutation 'foo[n...-2]'
   mutation 'foo[nil..-2]'
   mutation 'foo[self..-2]'
-  mutation 'foo[n..(1.0 / 0.0)]'
-  mutation 'foo[n..(0.0 / 0.0)]'
-  mutation 'foo[(0.0 / 0.0)..-2]'
 end
 
 Mutant::Meta::Example.add :send do
@@ -568,9 +562,6 @@ Mutant::Meta::Example.add :send do
   mutation 'foo[n...-2]'
   mutation 'foo[nil...-1]'
   mutation 'foo[self...-1]'
-  mutation 'foo[n...(1.0 / 0.0)]'
-  mutation 'foo[n...(0.0 / 0.0)]'
-  mutation 'foo[(0.0 / 0.0)...-1]'
 end
 
 Mutant::Meta::Example.add :send do
@@ -594,9 +585,6 @@ Mutant::Meta::Example.add :send do
   mutation 'foo[n...-1]'
   mutation 'foo[nil..-1]'
   mutation 'foo[self..-1]'
-  mutation 'foo[n..(1.0 / 0.0)]'
-  mutation 'foo[n..(0.0 / 0.0)]'
-  mutation 'foo[(0.0 / 0.0)..-1]'
   mutation 'foo.drop(n)'
 end
 


### PR DESCRIPTION
regarding #392 in the mutation-testing slack:

> So right now I think we should do the following:
* Remove mutations to infinite on ranges
* Lift visiblity for infinite runtime mutations in the readme

> Since I just recalled another fact: applying the N+1 mutation infinite times gives you infinite.

> @dgollahon: Feel free to submit your first PR to remove the range to infinite mutations, citing this discussion.

I don't think we discussed the `NaN` mutations, but they seemed also seemed worth removing to me while I was looking at the range mutator.

I also thought it'd be cool to get rid of emitting `nil`s in ranges, but I didn't know how to do that cleanly.

Let me know if you'd prefer the commits be squashed into one--part of why I kept them separate was because I didn't know if you'd disagree about removing `NaN` though I can't see what they could be used for.