### PR TITLE
Remove expect coverage

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 16
-total_score: 1290
+total_score: 1284

--- a/lib/mutant.rb
+++ b/lib/mutant.rb
@@ -204,7 +204,6 @@ module Mutant
   # Reopen class to initialize constant to avoid dep circle
   class Config
     DEFAULT = new(
-      expected_coverage: Rational(1),
       expression_parser: Expression::Parser.new([
         Expression::Method,
         Expression::Methods,

--- a/lib/mutant/cli.rb
+++ b/lib/mutant/cli.rb
@@ -1,8 +1,5 @@
 module Mutant
-
-  # Commandline parser
-  #
-  # rubocop:disable ClassLength
+  # Commandline parser / runner
   class CLI
     include Adamantium::Flat, Equalizer.new(:config), Procto.call(:config)
 
@@ -117,12 +114,6 @@ module Mutant
       opts.separator(nil)
       opts.separator('Options:')
 
-      opts.on(
-        '--expected-coverage COVERAGE',
-        'Fail unless COVERAGE is not reached exactly, parsed via Rational()'
-      ) do |coverage|
-        with(expected_coverage: Rational(coverage))
-      end
       opts.on('--use INTEGRATION', 'Use INTEGRATION to kill mutations', &method(:setup_integration))
     end
 

--- a/lib/mutant/config.rb
+++ b/lib/mutant/config.rb
@@ -5,7 +5,6 @@ module Mutant
   # to current environment is being represented by the Mutant::Env object.
   class Config
     include Adamantium::Flat, Anima.new(
-      :expected_coverage,
       :expression_parser,
       :fail_fast,
       :integration,

--- a/lib/mutant/reporter/cli/printer/config.rb
+++ b/lib/mutant/reporter/cli/printer/config.rb
@@ -14,7 +14,6 @@ module Mutant
             info 'Mutant configuration:'
             info 'Matcher:         %s',      object.matcher.inspect
             info 'Integration:     %s',      object.integration
-            info 'Expect Coverage: %0.2f%%', (object.expected_coverage * 100)
             info 'Jobs:            %d',      object.jobs
             info 'Includes:        %s',      object.includes
             info 'Requires:        %s',      object.requires

--- a/lib/mutant/reporter/cli/printer/env_progress.rb
+++ b/lib/mutant/reporter/cli/printer/env_progress.rb
@@ -28,8 +28,7 @@ module Mutant
             [:info,   'Killtime:        %0.2fs',  :killtime                 ],
             [:info,   'Overhead:        %0.2f%%', :overhead_percent         ],
             [:info,   'Mutations/s:     %0.2f',   :mutations_per_second     ],
-            [:status, 'Coverage:        %0.2f%%', :coverage_percent         ],
-            [:status, 'Expected:        %0.2f%%', :expected_coverage_percent]
+            [:status, 'Coverage:        %0.2f%%', :coverage_percent         ]
           ])
 
           # Run printer
@@ -60,15 +59,6 @@ module Mutant
           # @api private
           def coverage_percent
             coverage * 100
-          end
-
-          # Expected coverage in percent
-          #
-          # @return [Float]
-          #
-          # @api private
-          def expected_coverage_percent
-            env.config.expected_coverage * 100
           end
 
           # Overhead in percent

--- a/lib/mutant/result.rb
+++ b/lib/mutant/result.rb
@@ -76,7 +76,7 @@ module Mutant
       #
       # @return [Boolean]
       def success?
-        coverage.eql?(env.config.expected_coverage)
+        coverage.eql?(Rational(1))
       end
       memoize :success?
 

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -4,7 +4,6 @@
   repo_uri: 'https://github.com/ruby/rubyspec.git'
   mutation_coverage: false
   mutation_generation: true
-  expect_coverage: 0 # not run
   expected_errors:
     "#<Parser::SyntaxError: invalid multibyte escape: /\xAA/>":
       - language/regexp/escapes_spec.rb
@@ -95,7 +94,6 @@
   repo_uri: 'https://github.com/ammar/regexp_parser.git'
   mutation_coverage: false
   mutation_generation: true
-  expect_coverage: 0 # not run
   expected_errors: {}
 - name: auom
   namespace: AUOM
@@ -103,11 +101,9 @@
   mutation_coverage: true
   mutation_generation: true
   expected_errors: {}
-  expect_coverage: 1
 - name: axiom
   namespace: Axiom
   repo_uri: 'https://github.com/dkubb/axiom.git'
   mutation_coverage: false
   mutation_generation: true
   expected_errors: {}
-  expect_coverage: 1

--- a/spec/support/corpus.rb
+++ b/spec/support/corpus.rb
@@ -318,12 +318,7 @@ module MutantSpec
                         ->(hash) { hash.map { |key, values| [key, values.map(&:to_s)]                 }.to_h }
                       ]),
                     s(:load_attribute_hash, s(:param, ErrorWhitelist))))),
-              s(:load_attribute_hash,
-                # NOTE: The domain param has no DSL currently!
-                Morpher::Evaluator::Transformer::Domain::Param.new(
-                  Project,
-                  %i[repo_uri name expected_errors mutation_coverage mutation_generation]
-                )))))
+              s(:anima_load, Project))))
       end
 
       ALL = LOADER.call(YAML.load_file(ROOT.join('spec', 'integrations.yml')))

--- a/spec/support/corpus.rb
+++ b/spec/support/corpus.rb
@@ -32,7 +32,6 @@ module MutantSpec
       DEFAULT_MUTATION_COUNT = 0
 
       include Adamantium, Anima.new(
-        :expect_coverage,
         :expected_errors,
         :mutation_coverage,
         :mutation_generation,
@@ -58,7 +57,6 @@ module MutantSpec
                 --use rspec
                 --include lib
                 --require #{name}
-                --expected-coverage #{expect_coverage}
                 #{namespace}*
               ]
             )
@@ -304,7 +302,6 @@ module MutantSpec
                 s(:key_symbolize, :repo_uri,            s(:guard, s(:primitive, String))),
                 s(:key_symbolize, :name,                s(:guard, s(:primitive, String))),
                 s(:key_symbolize, :namespace,           s(:guard, s(:primitive, String))),
-                s(:key_symbolize, :expect_coverage,     s(:guard, s(:primitive, Fixnum))),
                 s(:key_symbolize, :mutation_coverage,
                   s(:guard, s(:or, s(:primitive, TrueClass), s(:primitive, FalseClass)))),
                 s(:key_symbolize, :mutation_generation,

--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -125,7 +125,6 @@ Environment:
     -j, --jobs NUMBER                Number of kill jobs. Defaults to number of processors.
 
 Options:
-        --expected-coverage COVERAGE Fail unless COVERAGE is not reached exactly, parsed via Rational()
         --use INTEGRATION            Use INTEGRATION to kill mutations
         --ignore-subject EXPRESSION  Ignore subjects that match EXPRESSION as prefix
         --since REVISION             Only select subjects touched since REVISION
@@ -191,38 +190,6 @@ Options:
 
       it 'configures expected coverage' do
         expect(subject.config.jobs).to eql(0)
-      end
-    end
-
-    context 'with expected-coverage flag' do
-      context 'given as decimal' do
-        let(:flags) { %w[--expected-coverage 0.1] }
-
-        it_should_behave_like 'a cli parser'
-
-        it 'configures expected coverage' do
-          expect(subject.config.expected_coverage).to eql(Rational(1, 10))
-        end
-      end
-
-      context 'given as scientific' do
-        let(:flags) { %w[--expected-coverage 1e-1] }
-
-        it_should_behave_like 'a cli parser'
-
-        it 'configures expected coverage' do
-          expect(subject.config.expected_coverage).to eql(Rational(1, 10))
-        end
-      end
-
-      context 'given as rational' do
-        let(:flags) { %w[--expected-coverage 1/10] }
-
-        it_should_behave_like 'a cli parser'
-
-        it 'configures expected coverage' do
-          expect(subject.config.expected_coverage).to eql(Rational(1, 10))
-        end
       end
     end
 

--- a/spec/unit/mutant/reporter/cli/printer/config_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/config_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Config do
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     Mutant::Integration::Null
-        Expect Coverage: 100.00%
         Jobs:            1
         Includes:        []
         Requires:        []
@@ -17,13 +16,10 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Config do
     end
 
     context 'with non default coverage expectation' do
-      with(:config) { { expected_coverage: 0.1r } }
-
       it_reports(<<-REPORT)
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     Mutant::Integration::Null
-        Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []
         Requires:        []

--- a/spec/unit/mutant/reporter/cli/printer/env_progress_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/env_progress_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
   setup_shared_context
 
-  with(:config) { { expected_coverage: 0.1r } }
-
   let(:reportable) { env_result }
 
   describe '.call' do
@@ -13,7 +11,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     Mutant::Integration::Null
-        Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []
         Requires:        []
@@ -27,7 +24,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Overhead:        Inf%
         Mutations/s:     0.00
         Coverage:        100.00%
-        Expected:        10.00%
       STR
     end
 
@@ -36,7 +32,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     Mutant::Integration::Null
-        Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []
         Requires:        []
@@ -50,7 +45,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Overhead:        100.00%
         Mutations/s:     0.50
         Coverage:        100.00%
-        Expected:        10.00%
       STR
     end
 
@@ -61,7 +55,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     Mutant::Integration::Null
-        Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []
         Requires:        []
@@ -75,7 +68,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Overhead:        100.00%
         Mutations/s:     0.50
         Coverage:        50.00%
-        Expected:        10.00%
       STR
     end
   end

--- a/spec/unit/mutant/reporter/cli/printer/env_result_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/env_result_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvResult do
       Mutant configuration:
       Matcher:         #<Mutant::Matcher::Config empty>
       Integration:     Mutant::Integration::Null
-      Expect Coverage: 100.00%
       Jobs:            1
       Includes:        []
       Requires:        []
@@ -31,7 +30,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvResult do
       Overhead:        100.00%
       Mutations/s:     0.50
       Coverage:        50.00%
-      Expected:        100.00%
     STR
   end
 end

--- a/spec/unit/mutant/reporter/cli/printer/status_progressive_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/status_progressive_spec.rb
@@ -10,14 +10,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::StatusProgressive do
       it_reports <<-REPORT
         (00/02) 100% - killtime: 0.00s runtime: 4.00s overhead: 4.00s
       REPORT
-
-      context 'on non default coverage expectation' do
-        with(:config) { { expected_coverage: 0.1r } }
-
-        it_reports <<-REPORT
-          (00/02) 100% - killtime: 0.00s runtime: 4.00s overhead: 4.00s
-        REPORT
-      end
     end
 
     context 'with scheduler active on one subject' do

--- a/spec/unit/mutant/reporter/cli/printer/status_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/status_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     Mutant::Integration::Null
-        Expect Coverage: 100.00%
         Jobs:            1
         Includes:        []
         Requires:        []
@@ -25,35 +24,8 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
         Overhead:        Inf%
         Mutations/s:     0.00
         Coverage:        100.00%
-        Expected:        100.00%
         Active subjects: 0
       REPORT
-
-      context 'on non default coverage expectation' do
-        with(:config) { { expected_coverage: 0.1r } }
-
-        it_reports <<-REPORT
-          Mutant configuration:
-          Matcher:         #<Mutant::Matcher::Config empty>
-          Integration:     Mutant::Integration::Null
-          Expect Coverage: 10.00%
-          Jobs:            1
-          Includes:        []
-          Requires:        []
-          Subjects:        1
-          Mutations:       2
-          Results:         0
-          Kills:           0
-          Alive:           0
-          Runtime:         4.00s
-          Killtime:        0.00s
-          Overhead:        Inf%
-          Mutations/s:     0.00
-          Coverage:        100.00%
-          Expected:        10.00%
-          Active subjects: 0
-        REPORT
-      end
     end
 
     context 'with scheduler active on one subject' do
@@ -64,7 +36,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
           Mutant configuration:
           Matcher:         #<Mutant::Matcher::Config empty>
           Integration:     Mutant::Integration::Null
-          Expect Coverage: 100.00%
           Jobs:            1
           Includes:        []
           Requires:        []
@@ -78,7 +49,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
           Overhead:        100.00%
           Mutations/s:     0.50
           Coverage:        100.00%
-          Expected:        100.00%
           Active subjects: 0
         REPORT
       end
@@ -93,7 +63,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
             Mutant configuration:
             Matcher:         #<Mutant::Matcher::Config empty>
             Integration:     Mutant::Integration::Null
-            Expect Coverage: 100.00%
             Jobs:            1
             Includes:        []
             Requires:        []
@@ -107,7 +76,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
             Overhead:        100.00%
             Mutations/s:     0.50
             Coverage:        50.00%
-            Expected:        100.00%
             Active Jobs:
             0: evil:subject-a:d27d2
             1: evil:subject-a:d5a9d
@@ -123,7 +91,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
             Mutant configuration:
             Matcher:         #<Mutant::Matcher::Config empty>
             Integration:     Mutant::Integration::Null
-            Expect Coverage: 100.00%
             Jobs:            1
             Includes:        []
             Requires:        []
@@ -137,7 +104,6 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Status do
             Overhead:        100.00%
             Mutations/s:     0.50
             Coverage:        100.00%
-            Expected:        100.00%
             Active Jobs:
             0: evil:subject-a:d27d2
             1: evil:subject-a:d5a9d

--- a/spec/unit/mutant/reporter/cli_spec.rb
+++ b/spec/unit/mutant/reporter/cli_spec.rb
@@ -122,23 +122,6 @@ RSpec.describe Mutant::Reporter::CLI do
         Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     Mutant::Integration::Null
-        Expect Coverage: 100.00%
-        Jobs:            1
-        Includes:        []
-        Requires:        []
-      REPORT
-    end
-
-    context 'with non default coverage expectation' do
-      let(:format) { progressive_format }
-
-      with(:config) { { expected_coverage: 0.1r } }
-
-      it_reports(<<-REPORT)
-        Mutant configuration:
-        Matcher:         #<Mutant::Matcher::Config empty>
-        Integration:     Mutant::Integration::Null
-        Expect Coverage: 10.00%
         Jobs:            1
         Includes:        []
         Requires:        []
@@ -157,7 +140,6 @@ RSpec.describe Mutant::Reporter::CLI do
       Mutant configuration:
       Matcher:         #<Mutant::Matcher::Config empty>
       Integration:     Mutant::Integration::Null
-      Expect Coverage: 100.00%
       Jobs:            1
       Includes:        []
       Requires:        []
@@ -171,7 +153,6 @@ RSpec.describe Mutant::Reporter::CLI do
       Overhead:        100.00%
       Mutations/s:     0.50
       Coverage:        100.00%
-      Expected:        100.00%
     REPORT
   end
 
@@ -185,7 +166,6 @@ RSpec.describe Mutant::Reporter::CLI do
         [tput-restore]Mutant configuration:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     Mutant::Integration::Null
-        Expect Coverage: 100.00%
         Jobs:            1
         Includes:        []
         Requires:        []
@@ -199,7 +179,6 @@ RSpec.describe Mutant::Reporter::CLI do
         Overhead:        100.00%
         Mutations/s:     0.50
         Coverage:        100.00%
-        Expected:        100.00%
         Active subjects: 0
       REPORT
     end

--- a/spec/unit/mutant/result/env_spec.rb
+++ b/spec/unit/mutant/result/env_spec.rb
@@ -17,10 +17,7 @@ RSpec.describe Mutant::Result::Env do
   end
 
   let(:config) do
-    instance_double(
-      Mutant::Config,
-      expected_coverage: Rational(1, 1)
-    )
+    instance_double(Mutant::Config)
   end
 
   let(:subject_result) do


### PR DESCRIPTION
This is the most misused option I've seen so far in the wild. It does not support a good workflow. Hence killing it so users are forced to use a better strategy (exclusions) is the way to go.

I for my own projects never use this option, hence due my OSS policy it has no reason to stay.