### PR TITLE
Remove Node::Regexp::Generic

### DIFF
--- a/lib/mutant/mutator/node/generic.rb
+++ b/lib/mutant/mutator/node/generic.rb
@@ -5,16 +5,45 @@ module Mutant
       # Generic mutator
       class Generic < self
 
+        unsupported_nodes = %i[
+          ensure
+          redo
+          retry
+          arg_expr
+          blockarg
+          kwrestarg
+          undef
+          module
+          empty
+          alias
+          for
+          xstr
+          back_ref
+          restarg
+          sclass
+          match_with_lvasgn
+          while_post
+          until_post
+          preexe
+          postexe
+          iflipflop
+          eflipflop
+          kwsplat
+          shadowarg
+          rational
+          complex
+          __FILE__
+          __LINE__
+        ]
+
+        unsupported_regexp_nodes = AST::Types::REGEXP.to_a - %i[
+          regexp_root_expression
+          regexp_bol_anchor
+        ]
+
         # These nodes still need a dedicated mutator,
         # your contribution is that close!
-        handle(
-          :ensure, :redo, :retry, :arg_expr, :blockarg,
-          :kwrestarg, :undef, :module, :empty,
-          :alias, :for, :xstr, :back_ref, :restarg,
-          :sclass, :match_with_lvasgn, :while_post,
-          :until_post, :preexe, :postexe, :iflipflop, :eflipflop, :kwsplat,
-          :shadowarg, :rational, :complex, :__FILE__, :__LINE__
-        )
+        handle(*(unsupported_nodes + unsupported_regexp_nodes))
 
       private
 

--- a/lib/mutant/mutator/node/regexp.rb
+++ b/lib/mutant/mutator/node/regexp.rb
@@ -2,17 +2,6 @@ module Mutant
   class Mutator
     class Node
       module Regexp
-        # Generic regexp mutator
-        class Generic < Node
-          handle(*(AST::Types::REGEXP - %i[regexp_root_expression regexp_bol_anchor]))
-
-          # Noop dispatch
-          #
-          # @return [undefined]
-          def dispatch
-          end
-        end # Generic
-
         # Mutator for root expression regexp wrapper
         class RootExpression < Node
           handle(:regexp_root_expression)


### PR DESCRIPTION
Extracted from #633. For regexp mutations to be useful the node types which do not have dedicated mutators need to at least invoke the mutators for their children in order to be helpful. This change makes a separate generic mutator for regular expressions unnecessary