### PR TITLE
Fix indeterminism from include_context condition

### DIFF
--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('concord',       '~> 0.1.5')
   gem.add_runtime_dependency('regexp_parser', '~> 0.3.6')
 
-  gem.add_development_dependency('devtools', '~> 0.1.4')
+  gem.add_development_dependency('devtools', '= 0.1.10')
   gem.add_development_dependency('bundler',  '~> 1.10')
   gem.add_development_dependency('ffi',      '~> 1.9.6')
 end

--- a/spec/support/warnings.yml
+++ b/spec/support/warnings.yml
@@ -1,4 +1,4 @@
 ---
-- 'lib/parser/lexer.rb:10791: warning: assigned but unused variable - testEof'
+- 'lib/parser/lexer.rb:10922: warning: assigned but unused variable - testEof'
 - 'lib/parser/source/rewriter.rb:392: warning: assigned but unused variable - begin_pos'
 - 'lib/regexp_parser/scanner.rb:1646: warning: assigned but unused variable - testEof'

--- a/spec/unit/mutant/ast/regexp_spec.rb
+++ b/spec/unit/mutant/ast/regexp_spec.rb
@@ -70,9 +70,9 @@ module RegexpSpec
 
         include_context 'regexp transformation'
 
-        return if regexp.encoding.name.eql?('ASCII-8BIT')
-
-        include_context 'regexp round trip'
+        unless regexp.encoding.name.eql?('ASCII-8BIT')
+          include_context 'regexp round trip'
+        end
       end
     end
   end


### PR DESCRIPTION
It looks like this guard clause was causing issues that led to
the build sometimes failing with

    super: no superclass method `expression'

this change fixes this issue

Extracted from #640