### PR TITLE
Upgrade to latest devtools

### DIFF
--- a/lib/mutant/env/bootstrap.rb
+++ b/lib/mutant/env/bootstrap.rb
@@ -56,16 +56,21 @@ module Mutant
         Env.new(
           actor_env:        Actor::Env.new(Thread),
           config:           config,
-          integration:      @integration,
+          integration:      integration,
           matchable_scopes: matchable_scopes,
           mutations:        subjects.flat_map(&:mutations),
           parser:           parser,
-          selector:         Selector::Expression.new(@integration),
+          selector:         Selector::Expression.new(integration),
           subjects:         subjects
         )
       end
 
     private
+
+      # Configured mutant integration
+      #
+      # @return [Mutant::Integration]
+      attr_reader :integration
 
       # Scope name from scoping object
       #

--- a/lib/mutant/reporter/cli.rb
+++ b/lib/mutant/reporter/cli.rb
@@ -9,6 +9,8 @@ module Mutant
       # @param [IO] output
       #
       # @return [Reporter::CLI]
+      #
+      # :reek:ManualDispatch
       def self.build(output)
         tput = Tput.detect
         tty = output.respond_to?(:tty?) && output.tty?

--- a/lib/mutant/zombifier.rb
+++ b/lib/mutant/zombifier.rb
@@ -38,6 +38,11 @@ module Mutant
 
   private
 
+    # Original require method
+    #
+    # @return [Method]
+    attr_reader :original
+
     # Run zombifier
     #
     # @return [undefined]
@@ -61,7 +66,7 @@ module Mutant
     #   true if successful and false if feature already loaded
     def require(logical_name)
       logical_name = logical_name.to_s
-      loaded = @original.call(logical_name)
+      loaded = original.call(logical_name)
       return loaded unless include?(logical_name)
       @zombified << logical_name
       zombify(find(logical_name))

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency('parser',        '~> 2.3.0', '>= 2.3.0.2')
+  gem.add_runtime_dependency('parser',        '= 2.3.1.2')
   gem.add_runtime_dependency('ast',           '~> 2.2')
   gem.add_runtime_dependency('diff-lcs',      '~> 1.2')
   gem.add_runtime_dependency('parallel',      '~> 1.3')
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('concord',       '~> 0.1.5')
   gem.add_runtime_dependency('regexp_parser', '~> 0.3.6')
 
-  gem.add_development_dependency('devtools', '~> 0.1.4')
+  gem.add_development_dependency('devtools', '= 0.1.10')
   gem.add_development_dependency('bundler',  '~> 1.10')
   gem.add_development_dependency('ffi',      '~> 1.9.6')
 end

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency('parser',        '= 2.3.1.2')
+  gem.add_runtime_dependency('parser',        '~> 2.3.1', '>= 2.3.1.4')
   gem.add_runtime_dependency('ast',           '~> 2.2')
   gem.add_runtime_dependency('diff-lcs',      '~> 1.2')
   gem.add_runtime_dependency('parallel',      '~> 1.3')

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('concord',       '~> 0.1.5')
   gem.add_runtime_dependency('regexp_parser', '~> 0.3.6')
 
-  gem.add_development_dependency('devtools', '= 0.1.10')
+  gem.add_development_dependency('devtools', '~> 0.1.12')
   gem.add_development_dependency('bundler',  '~> 1.10')
   gem.add_development_dependency('ffi',      '~> 1.9.6')
 end

--- a/spec/support/warnings.yml
+++ b/spec/support/warnings.yml
@@ -1,4 +1,4 @@
 ---
-- 'lib/parser/lexer.rb:10791: warning: assigned but unused variable - testEof'
+- 'lib/parser/lexer.rb:10922: warning: assigned but unused variable - testEof'
 - 'lib/parser/source/rewriter.rb:392: warning: assigned but unused variable - begin_pos'
 - 'lib/regexp_parser/scanner.rb:1646: warning: assigned but unused variable - testEof'

--- a/spec/unit/mutant/ast/regexp_spec.rb
+++ b/spec/unit/mutant/ast/regexp_spec.rb
@@ -70,9 +70,9 @@ module RegexpSpec
 
         include_context 'regexp transformation'
 
-        return if regexp.encoding.name.eql?('ASCII-8BIT')
-
-        include_context 'regexp round trip'
+        unless regexp.encoding.name.eql?('ASCII-8BIT')
+          include_context 'regexp round trip'
+        end
       end
     end
   end


### PR DESCRIPTION
Devtools 0.1.10 upgraded to RSpec 3.5 which broke this behavior https://github.com/mbj/mutant/blob/770f34eee55b92bf6066b13c917da50215c16dd5/spec/unit/mutant/ast/regexp_spec.rb#L73.

The second commit upgrades to the latest devtools version which upgrades reek and requires working around a few new smells. One of the smells is `InstanceVariableAssumption` which flags code that uses instance variables that were not initialized in the the `#initialize` method. I've fixed these smells by introducing private attribute readers. The other smell is a `ManualDispatch` smell which I've added a reek ignore for.

Finally, I've updated the spec warnings file to match a parser update

Extracted from #640