### PR TITLE
Sort regexp nodes lexicographically

### DIFF
--- a/lib/mutant/mutator/node/generic.rb
+++ b/lib/mutant/mutator/node/generic.rb
@@ -37,17 +37,17 @@ module Mutant
         ]
 
         unsupported_regexp_nodes = AST::Types::REGEXP.to_a - %i[
-          regexp_root_expression
+          regexp_alternation_meta
           regexp_bol_anchor
-          regexp_word_type
-          regexp_nonword_type
           regexp_digit_type
           regexp_nondigit_type
-          regexp_space_type
           regexp_nonspace_type
-          regexp_word_boundary_anchor
           regexp_nonword_boundary_anchor
-          regexp_alternation_meta
+          regexp_nonword_type
+          regexp_root_expression
+          regexp_space_type
+          regexp_word_boundary_anchor
+          regexp_word_type
         ]
 
         # These nodes still need a dedicated mutator,

--- a/lib/mutant/mutator/node/regexp/character_type.rb
+++ b/lib/mutant/mutator/node/regexp/character_type.rb
@@ -5,10 +5,10 @@ module Mutant
         # Character type mutator
         class CharacterType < Node
           map = {
-            regexp_word_type:            :regexp_nonword_type,
             regexp_digit_type:           :regexp_nondigit_type,
             regexp_space_type:           :regexp_nonspace_type,
-            regexp_word_boundary_anchor: :regexp_nonword_boundary_anchor
+            regexp_word_boundary_anchor: :regexp_nonword_boundary_anchor,
+            regexp_word_type:            :regexp_nonword_type
           }
 
           MAP = IceNine.deep_freeze(map.merge(map.invert))

--- a/meta/regexp/character_types.rb
+++ b/meta/regexp/character_types.rb
@@ -1,8 +1,8 @@
 mutations = {
-  [:regexp_word_type,            '/\w/'] => [:regexp_nonword_type,            '/\W/'],
   [:regexp_digit_type,           '/\d/'] => [:regexp_nondigit_type,           '/\D/'],
   [:regexp_space_type,           '/\s/'] => [:regexp_nonspace_type,           '/\S/'],
-  [:regexp_word_boundary_anchor, '/\b/'] => [:regexp_nonword_boundary_anchor, '/\B/']
+  [:regexp_word_boundary_anchor, '/\b/'] => [:regexp_nonword_boundary_anchor, '/\B/'],
+  [:regexp_word_type,            '/\w/'] => [:regexp_nonword_type,            '/\W/']
 }
 
 mutations = mutations.merge(mutations.invert)


### PR DESCRIPTION
- To reduce diff noise in following PRs and have a well-defined ordering
  of nodes.