### PR TITLE
Fix rspec warning about ordered stubs

### DIFF
--- a/spec/unit/mutant/reporter/cli/tput_spec.rb
+++ b/spec/unit/mutant/reporter/cli/tput_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Mutant::Reporter::CLI::Tput do
     subject { described_class.detect }
 
     def expect_command(command, stdout, success)
-      allow(Open3).to receive(:capture3).with(command).ordered.and_return(
+      allow(Open3).to receive(:capture3).with(command).and_return(
         [
           stdout,
           instance_double(IO),


### PR DESCRIPTION
Previously the spec output was spammed with

```
WARNING: `allow(...).to receive(..).ordered` is not supported and willhave no effect, use `and_return(*ordered_values)` instead.. Called from /home/dev/mutant/spec/unit/mutant/reporter/cli/tput_spec.rb:6:in `expect_command'.
```