### PR TITLE
Fix spec warning assertions when running specs under mutant

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ end
 
 # Require warning support first in order to catch any warnings emitted during boot
 require_relative './support/warning'
-$stderr = MutantSpec::Warning::EXTRACTOR
+$stderr = MutantSpec::Warning.warning_hijacker_for($PROGRAM_NAME)
 
 require 'tempfile'
 require 'concord'

--- a/spec/support/warning.rb
+++ b/spec/support/warning.rb
@@ -5,6 +5,24 @@ require 'ice_nine'
 
 module MutantSpec
   class Warning
+    # Return `$stderr` hijack if the top level program is rspec
+    #
+    # Certain mutations emit warnings which can cause an otherwise passing mutant run
+    #   to fail. For example, the `remove_method` mutation will emit a warning when
+    #   applied to certain methods like `#initialize`, `#object_id`, and `#__send__`.
+    #
+    # @param program_name [String] name of top level program
+    #
+    # @return [Warning::Extractor] if the top level program is rspec
+    # @return [$stderr] otherwise
+    def self.warning_hijacker_for(program_name)
+      if File.basename(program_name).eql?('rspec')
+        MutantSpec::Warning::EXTRACTOR
+      else
+        STDERR
+      end
+    end
+
     def self.assert_no_warnings
       return if EXTRACTOR.warnings.empty?
 


### PR DESCRIPTION
Certain mutations emit warnings which can cause an otherwise passing
mutant run to fail. For example, the `remove_method` mutation will
emit a warning when applied to certain methods like `#initialize`,
`#object_id`, and `#__send__`.

See https://git.io/vPiFS