### PR TITLE
Improve fork isolation spec

### DIFF
--- a/spec/integration/mutant/isolation/fork_spec.rb
+++ b/spec/integration/mutant/isolation/fork_spec.rb
@@ -1,8 +1,49 @@
 RSpec.describe Mutant::Isolation::Fork, mutant: false do
-  specify do
-    a = 1
+  def apply(&block)
+    Mutant::Config::DEFAULT.isolation.call(&block)
+  end
+
+  it 'does isolate side effects' do
+    initial = 1
+    apply { initial = 2  }
+    expect(initial).to be(1)
+  end
+
+  it 'return block value' do
+    expect(apply { :foo }).to be(:foo)
+  end
+
+  it 'wraps exceptions' do
+    expect { apply { fail } }.to raise_error(Mutant::Isolation::Error)
+  end
+
+  it 'wraps exceptions caused by crashing ruby' do
     expect do
-      Mutant::Config::DEFAULT.isolation.call { a = 2 }
-    end.to_not change { a }
+      apply { fail RbBug.call }
+    end.to raise_error(Mutant::Isolation::Error)
+  end
+
+  it 'redirects $stderr of children to /dev/null' do
+    begin
+      Tempfile.open('mutant-test') do |file|
+        $stderr = file
+        apply { $stderr.puts('test') }
+        expect(file.read).to eql('')
+      end
+    ensure
+      $stderr = STDERR
+    end
+  end
+
+  it 'redirects $stdout of children to /dev/null' do
+    begin
+      Tempfile.open('mutant-test') do |file|
+        $stdout = file
+        apply { $stdout.puts('test') }
+        expect(file.read).to eql('')
+      end
+    ensure
+      $stderr = STDOUT
+    end
   end
 end


### PR DESCRIPTION
Stole this from @mbj on minitest branch

My thought is if we take the generic changes off of minitest branch, then in the future, it will be easier to merge minitest

If it makes sense to merge this into master, great. If not, then just close