### PR TITLE
Update integrations.yml to reflect rubySpec update

### DIFF
--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -7,25 +7,6 @@
   expected_errors:
     "#<Parser::SyntaxError: invalid multibyte escape: /\xAA/>":
       - language/regexp/escapes_spec.rb
-    "#<Parser::SyntaxError: literal contains escape sequences incompatible with UTF-8>":
-      - core/string/shared/each_codepoint_without_block.rb
-      - core/string/shared/encode.rb
-      - core/string/shared/eql.rb
-      - core/string/shared/succ.rb
-      - core/string/slice_spec.rb
-      - core/string/squeeze_spec.rb
-      - core/string/unicode_normalize_spec.rb
-      - core/string/valid_encoding_spec.rb
-      - core/symbol/casecmp_spec.rb
-      - core/time/_dump_spec.rb
-      - core/time/_load_spec.rb
-      - language/regexp/encoding_spec.rb
-      - language/string_spec.rb
-      - library/openssl/shared/constants.rb
-      - library/socket/socket/gethostbyname_spec.rb
-      - library/zlib/inflate/set_dictionary_spec.rb
-      - optional/capi/encoding_spec.rb
-      - optional/capi/string_spec.rb
     '#<RegexpError: invalid multibyte escape: /\xAA/>':
       - language/regexp/escapes_spec.rb
     "#<Regexp::Scanner::PrematureEndError: Premature end of pattern at #{str}>":


### PR DESCRIPTION
@backus This is the last of the incompatible utf-8 escape sequence errors so I removed the entire section from integrations.yml :smiley: 
How are you detecting the regexp parse error - I'm not getting that?