### PR TITLE
Add support for regexp_bol_escape

### DIFF
--- a/lib/mutant/ast/regexp/transformer/direct.rb
+++ b/lib/mutant/ast/regexp/transformer/direct.rb
@@ -50,6 +50,7 @@ module Mutant
               [:regexp_set_open_escape,          [:escape,   :set_open,         '\['],           ::Regexp::Expression::EscapeSequence::Literal],
               [:regexp_set_close_escape,         [:escape,   :set_close,        '\]'],           ::Regexp::Expression::EscapeSequence::Literal],
               [:regexp_eol_escape,               [:escape,   :eol,              '\$'],           ::Regexp::Expression::EscapeSequence::Literal],
+              [:regexp_bol_escape,               [:escape,   :bol,              '\^'],           ::Regexp::Expression::EscapeSequence::Literal],
               [:regexp_bell_escape,              [:escape,   :bell,             '\a'],           ::Regexp::Expression::EscapeSequence::Literal],
               [:regexp_escape_escape,            [:escape,   :escape,           '\e'],           ::Regexp::Expression::EscapeSequence::AsciiEscape],
               [:regexp_form_feed_escape,         [:escape,   :form_feed,        '\f'],           ::Regexp::Expression::EscapeSequence::FormFeed],

--- a/lib/mutant/ast/types.rb
+++ b/lib/mutant/ast/types.rb
@@ -50,6 +50,7 @@ module Mutant
         regexp_backslash_escape
         regexp_bell_escape
         regexp_bol_anchor
+        regexp_bol_escape
         regexp_bos_anchor
         regexp_capture_group
         regexp_carriage_escape

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -7,29 +7,12 @@
   expected_errors:
     "#<Parser::SyntaxError: invalid multibyte escape: /\xAA/>":
       - language/regexp/escapes_spec.rb
-    "#<Parser::SyntaxError: literal contains escape sequences incompatible with UTF-8>":
-      - core/string/shared/each_codepoint_without_block.rb
-      - core/string/shared/encode.rb
-      - core/string/shared/eql.rb
-      - core/string/shared/succ.rb
-      - core/string/slice_spec.rb
-      - core/string/squeeze_spec.rb
-      - core/string/unicode_normalize_spec.rb
-      - core/string/valid_encoding_spec.rb
-      - core/symbol/casecmp_spec.rb
-      - core/time/_dump_spec.rb
-      - core/time/_load_spec.rb
-      - language/regexp/encoding_spec.rb
-      - language/string_spec.rb
-      - library/openssl/shared/constants.rb
-      - library/socket/socket/gethostbyname_spec.rb
-      - library/zlib/inflate/set_dictionary_spec.rb
-      - optional/capi/encoding_spec.rb
-      - optional/capi/string_spec.rb
     '#<RegexpError: invalid multibyte escape: /\xAA/>':
       - language/regexp/escapes_spec.rb
     "#<Regexp::Scanner::PrematureEndError: Premature end of pattern at #{str}>":
       - language/regexp/interpolation_spec.rb
+    '#<Regexp::Scanner::PrematureEndError: Premature end of pattern at \xA>':
+      - language/regexp/escapes_spec.rb
 - name: regexp_parser
   namespace: Regexp
   repo_uri: 'https://github.com/ammar/regexp_parser.git'

--- a/spec/unit/mutant/ast/regexp_spec.rb
+++ b/spec/unit/mutant/ast/regexp_spec.rb
@@ -113,6 +113,11 @@ RegexpSpec.expect_mapping(/^/, :regexp_bol_anchor) do
     s(:regexp_bol_anchor))
 end
 
+RegexpSpec.expect_mapping(/\^/, :regexp_bol_escape) do
+  s(:regexp_root_expression,
+    s(:regexp_bol_escape))
+end
+
 RegexpSpec.expect_mapping(/\A/, :regexp_bos_anchor) do
   s(:regexp_root_expression,
     s(:regexp_bos_anchor))


### PR DESCRIPTION
This PR takes the changes in #687, fixes a bug that the upstream rubyspec changes uncovered, and adds one new exclusion to the `integrations.yml` which is visible now that utf-8 issues aren't prohibiting us from parsing the offending file