### PR TITLE
Fix invalid YARD type documentation

### DIFF
--- a/lib/mutant/ast/named_children.rb
+++ b/lib/mutant/ast/named_children.rb
@@ -23,7 +23,7 @@ module Mutant
 
         # Mutated nodes children
         #
-        # @return [Array<Parser::AST::Node]
+        # @return [Array<Parser::AST::Node>]
         def children
           node.children
         end

--- a/lib/mutant/ast/regexp.rb
+++ b/lib/mutant/ast/regexp.rb
@@ -10,14 +10,14 @@ module Mutant
       #
       # @param regexp [String]
       #
-      # @return [Regexp::Expression]
+      # @return [Regexp::Expression::Base]
       def self.parse(regexp)
         ::Regexp::Parser.parse(regexp)
       end
 
       # Check if expression is supported by mapper
       #
-      # @param expression [Regexp::Expression]
+      # @param expression [Regexp::Expression::Base]
       #
       # @return [Boolean]
       def self.supported?(expression)
@@ -28,7 +28,7 @@ module Mutant
 
       # Convert expression into ast node
       #
-      # @param expression [Regexp::Expression]
+      # @param expression [Regexp::Expression::Base]
       #
       # @return [Parser::AST::Node]
       def self.to_ast(expression)
@@ -41,7 +41,7 @@ module Mutant
       #
       # @param node [Parser::AST::Node]
       #
-      # @return [Regexp::Expression]
+      # @return [Regexp::Expression::Base]
       def self.to_expression(node)
         Transformer.lookup(node.type).to_expression(node)
       end

--- a/lib/mutant/ast/regexp/transformer.rb
+++ b/lib/mutant/ast/regexp/transformer.rb
@@ -32,7 +32,7 @@ module Mutant
 
         # Transform expression
         #
-        # @param expression [Regexp::Expression]
+        # @param expression [Regexp::Expression::Base]
         #
         # @return [Parser::AST::Node]
         def self.to_ast(expression)
@@ -43,7 +43,7 @@ module Mutant
         #
         # @param node [Parser::AST::Node]
         #
-        # @return [Regexp::Expression]
+        # @return [Regexp::Expression::Base]
         def self.to_expression(node)
           self::ASTToExpression.call(node)
         end
@@ -101,7 +101,7 @@ module Mutant
 
           # Call generic transform method and freeze result
           #
-          # @return [Regexp::Expression]
+          # @return [Regexp::Expression::Base]
           def call
             transform.freeze
           end
@@ -110,7 +110,7 @@ module Mutant
 
           # Transformation of ast into expression
           #
-          # @return [Regexp::Expression]
+          # @return [Regexp::Expression::Base]
           abstract_method :transform
 
           # Transformed children of node

--- a/lib/mutant/ast/regexp/transformer/character_set.rb
+++ b/lib/mutant/ast/regexp/transformer/character_set.rb
@@ -32,7 +32,7 @@ module Mutant
 
             # Transform node into expression
             #
-            # @return [Regexp::Expression]
+            # @return [Regexp::Expression::Base]
             def transform
               CHARACTER_SET.dup.tap do |expression|
                 expression.members = node.children

--- a/lib/mutant/ast/regexp/transformer/direct.rb
+++ b/lib/mutant/ast/regexp/transformer/direct.rb
@@ -87,7 +87,7 @@ module Mutant
 
             # Transform ast into expression
             #
-            # @return [Regexp::Expression]
+            # @return [Regexp::Expression::Base]
             def transform
               expression_class.new(expression_token)
             end

--- a/lib/mutant/ast/regexp/transformer/quantifier.rb
+++ b/lib/mutant/ast/regexp/transformer/quantifier.rb
@@ -49,7 +49,7 @@ module Mutant
 
             # Transform ast into quantifier attached to expression
             #
-            # @return [Regexp::Expression]
+            # @return [Regexp::Expression::Base]
             def transform
               Regexp.to_expression(subject).dup.tap do |expression|
                 expression.quantify(type, text, min, max, mode)
@@ -69,7 +69,7 @@ module Mutant
 
             # Type of quantifier
             #
-            # @return [:zero_or_more,:one_or_more,:interval]
+            # @return [Symbol] :zero_or_more, :one_or_more, or :interval
             def type
               quantifier.type
             end
@@ -83,7 +83,7 @@ module Mutant
 
             # The quantifier "mode"
             #
-            # @return [:greedy,:possessive,:reluctant]
+            # @return [Symbol] :greedy, :possessive, or :reluctant
             def mode
               quantifier.mode
             end

--- a/lib/mutant/ast/regexp/transformer/recursive.rb
+++ b/lib/mutant/ast/regexp/transformer/recursive.rb
@@ -34,7 +34,7 @@ module Mutant
 
             # Transform nodes and their children into expressions
             #
-            # @return [Regexp::Expression]
+            # @return [Regexp::Expression::Base]
             def transform
               expression_class.new(expression_token).tap do |expression|
                 expression.expressions = subexpressions

--- a/lib/mutant/ast/regexp/transformer/text.rb
+++ b/lib/mutant/ast/regexp/transformer/text.rb
@@ -39,7 +39,7 @@ module Mutant
 
             # Transform node to expression with text value
             #
-            # @return [Regexp::Expression]
+            # @return [Regexp::Expression::Base]
             def transform
               token = expression_token.dup
               token.text = Util.one(node.children)

--- a/lib/mutant/cli.rb
+++ b/lib/mutant/cli.rb
@@ -20,7 +20,7 @@ module Mutant
 
     # Initialize object
     #
-    # @param [Array<String>]
+    # @param arguments [Array<String>]
     #
     # @return [undefined]
     def initialize(arguments)

--- a/lib/mutant/context.rb
+++ b/lib/mutant/context.rb
@@ -74,7 +74,7 @@ module Mutant
 
     # Scope wrapped by context
     #
-    # @return [Module|Class]
+    # @return [Module,Class]
     attr_reader :scope
 
   private

--- a/lib/mutant/integration/rspec.rb
+++ b/lib/mutant/integration/rspec.rb
@@ -82,7 +82,7 @@ module Mutant
 
       # Index of available tests
       #
-      # @return [Hash<Test, RSpec::Core::Example]
+      # @return [Hash<Test, RSpec::Core::Example>]
       def all_tests_index
         all_examples.each_with_index.each_with_object({}) do |(example, example_index), index|
           index[parse_example(example, example_index)] = example
@@ -127,7 +127,7 @@ module Mutant
 
       # Available rspec examples
       #
-      # @return [Array<String, RSpec::Core::Example]
+      # @return [Array<String, RSpec::Core::Example>]
       def all_examples
         @world.example_groups.flat_map(&:descendants).flat_map(&:examples).select do |example|
           example.metadata.fetch(:mutant, true)

--- a/lib/mutant/matcher/method.rb
+++ b/lib/mutant/matcher/method.rb
@@ -98,7 +98,7 @@ module Mutant
 
         # Full source location
         #
-        # @return [Array{String,Fixnum}]
+        # @return [Array<String,Fixnum>]
         def source_location
           target_method.source_location
         end

--- a/lib/mutant/matcher/method/instance.rb
+++ b/lib/mutant/matcher/method/instance.rb
@@ -48,7 +48,7 @@ module Mutant
 
             # Source location
             #
-            # @return [Array{String,Fixnum}]
+            # @return [Array<String,Fixnum>]
             def source_location
               scope
                 .unmemoized_instance_method(method_name)

--- a/lib/mutant/matcher/methods.rb
+++ b/lib/mutant/matcher/methods.rb
@@ -27,7 +27,7 @@ module Mutant
 
       # method matcher class
       #
-      # @return [Class:Matcher::Method]
+      # @return [Class] Matcher::Method
       def matcher
         self.class::MATCHER
       end

--- a/lib/mutant/mutator/node/literal/range.rb
+++ b/lib/mutant/mutator/node/literal/range.rb
@@ -29,7 +29,7 @@ module Mutant
 
           # Inverse node
           #
-          # @return [Parser::AST::Node]
+          # @return [undefined]
           def emit_inverse
             emit(s(MAP.fetch(node.type), *children))
           end

--- a/lib/mutant/mutator/node/literal/regex.rb
+++ b/lib/mutant/mutator/node/literal/regex.rb
@@ -58,7 +58,7 @@ module Mutant
 
           # Expression representation of regexp body
           #
-          # @return [Regexp::Expression]
+          # @return [Regexp::Expression::Base]
           def body_expression
             AST::Regexp.parse(body.map(&:children).join)
           end

--- a/lib/mutant/parallel/worker.rb
+++ b/lib/mutant/parallel/worker.rb
@@ -10,7 +10,7 @@ module Mutant
 
       # Run worker
       #
-      # @param [Hash<Symbol, Object] attributes
+      # @param [Hash<Symbol, Object>] attributes
       #
       # @return [self]
       def self.run(attributes)

--- a/lib/mutant/reporter/cli/format.rb
+++ b/lib/mutant/reporter/cli/format.rb
@@ -49,7 +49,7 @@ module Mutant
 
         # Format object with printer
         #
-        # @param [Class:Printer] printer
+        # @param [Class] Printer
         # @param [Object] object
         #
         # @return [String]

--- a/lib/mutant/reporter/cli/printer.rb
+++ b/lib/mutant/reporter/cli/printer.rb
@@ -51,7 +51,7 @@ module Mutant
 
         # Visit a collection of objects
         #
-        # @return [Class::Printer] printer
+        # @return [Class] Printer
         # @return [Enumerable<Object>] collection
         #
         # @return [undefined]
@@ -63,7 +63,7 @@ module Mutant
 
         # Visit object
         #
-        # @param [Class::Printer] printer
+        # @param [Class] Printer
         # @param [Object] object
         #
         # @return [undefined]

--- a/spec/support/xspec.rb
+++ b/spec/support/xspec.rb
@@ -15,7 +15,7 @@ module XSpec
 
     # Parse events into reaction
     #
-    # @param [Array{Symbol,Object}, Hash{Symbol,Object}]
+    # @param [Array<Symbol,Object>, Hash{Symbol,Object}]
     #
     # @return [MessageReaction]
     def self.parse(events)


### PR DESCRIPTION
Upstreaming as requested in https://github.com/backus/mutest/pull/51

 - Fix documentation for regexp expression types. These returns and
   params inherit from Regexp::Expression::Base so we should use that
   when specifying the ancestor type

 - Fix some typos that fail to parse under YARD like `Array<Foo`

 - Tweak some documentation that specifies that a class is being passed
   in to YARD. Unfortunately there is no syntax for this so I have
   changed these to `@param [Class] Printer`