### PR TITLE
Define glob pattern for each repo

### DIFF
--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -3,6 +3,7 @@
   namespace: Rubyspec
   repo_uri: 'https://github.com/ruby/rubyspec.git'
   repo_ref: 'origin/master'
+  ruby_glob_pattern: '**/*_spec.rb'
   mutation_coverage: false
   mutation_generation: true
   expected_errors:
@@ -18,6 +19,7 @@
   namespace: Regexp
   repo_uri: 'https://github.com/ammar/regexp_parser.git'
   repo_ref: 'v0.4.1'
+  ruby_glob_pattern: '**/*.rb'
   mutation_coverage: false
   mutation_generation: true
   expected_errors:
@@ -27,6 +29,7 @@
   namespace: AUOM
   repo_uri: 'https://github.com/mbj/auom.git'
   repo_ref: 'origin/master'
+  ruby_glob_pattern: '**/*.rb'
   mutation_coverage: true
   mutation_generation: true
   expected_errors: {}
@@ -34,6 +37,7 @@
   namespace: Axiom
   repo_uri: 'https://github.com/dkubb/axiom.git'
   repo_ref: 'origin/master'
+  ruby_glob_pattern: '**/*.rb'
   mutation_coverage: false
   mutation_generation: true
   expected_errors: {}

--- a/spec/support/corpus.rb
+++ b/spec/support/corpus.rb
@@ -12,7 +12,6 @@ module MutantSpec
   module Corpus
     TMP                 = ROOT.join('tmp').freeze
     EXCLUDE_GLOB_FORMAT = '{%s}'.freeze
-    RUBY_GLOB_PATTERN   = '**/*.rb'.freeze
 
     # Not in the docs. Number from chatting with their support.
     # 2 processors allocated per container, 4 processes works well.
@@ -38,7 +37,8 @@ module MutantSpec
         :name,
         :namespace,
         :repo_uri,
-        :repo_ref
+        :repo_ref,
+        :ruby_glob_pattern
       )
 
       # Verify mutation coverage
@@ -174,7 +174,7 @@ module MutantSpec
       # @return [Array<Pathname>]
       def effective_ruby_paths
         Pathname
-          .glob(repo_path.join(RUBY_GLOB_PATTERN))
+          .glob(repo_path.join(ruby_glob_pattern))
           .sort_by(&:size)
           .reverse
       end
@@ -307,6 +307,7 @@ module MutantSpec
               s(:hash_transform,
                 s(:key_symbolize, :repo_uri,            s(:guard, s(:primitive, String))),
                 s(:key_symbolize, :repo_ref,            s(:guard, s(:primitive, String))),
+                s(:key_symbolize, :ruby_glob_pattern,   s(:guard, s(:primitive, String))),
                 s(:key_symbolize, :name,                s(:guard, s(:primitive, String))),
                 s(:key_symbolize, :namespace,           s(:guard, s(:primitive, String))),
                 s(:key_symbolize, :mutation_coverage,


### PR DESCRIPTION
This PR should fix the failing build.

This file was added not long ago to the rubyspec project https://github.com/ruby/spec/blob/master/command_line/fixtures/bad_syntax.rb

In the ruby corpus specs mutant iterates on all the rubyspec files. When [`Parser::CurrentRuby.parse(path.read)`](https://github.com/mbj/mutant/blob/master/spec/support/corpus.rb#L149) hits that file a `Parser::SyntaxError` is raised.

Since the offending file was created as a fixture, mutant probably shouldn't run it? 

This PR makes the glob pattern configurable on repository level for the integrations. I'm don't know if this a direct you want to take with these specs, but I created it more to show a one way to fix this issue.