### PR TITLE
Bump regexp_parser version to 0.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.8.13)
+    mutant (0.8.14)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.0)
@@ -15,10 +15,10 @@ PATH
       parallel (~> 1.3)
       parser (>= 2.3.1.4, < 2.5)
       procto (~> 0.0.2)
-      regexp_parser (~> 0.4.3)
+      regexp_parser (~> 0.4.4)
       unparser (~> 0.2.5)
-    mutant-rspec (0.8.13)
-      mutant (~> 0.8.13)
+    mutant-rspec (0.8.14)
+      mutant (~> 0.8.14)
       rspec-core (>= 3.4.0, < 3.7.0)
 
 GEM
@@ -105,7 +105,7 @@ GEM
       codeclimate-engine-rb (~> 0.4.0)
       parser (>= 2.4.0.0, < 2.5)
       rainbow (~> 2.0)
-    regexp_parser (0.4.3)
+    regexp_parser (0.4.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ jobs:
   ruby_2_3:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.3.3
+      - image: circleci/ruby:2.3.4
   ruby_2_4:
     <<: *defaults
     docker:

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('equalizer',     '~> 0.0.9')
   gem.add_runtime_dependency('anima',         '~> 0.3.0')
   gem.add_runtime_dependency('concord',       '~> 0.1.5')
-  gem.add_runtime_dependency('regexp_parser', '~> 0.4.3')
+  gem.add_runtime_dependency('regexp_parser', '~> 0.4.4')
 
   gem.add_development_dependency('devtools', '~> 0.1.12')
   gem.add_development_dependency('bundler',  '~> 1.10')

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -18,7 +18,7 @@
 - name: regexp_parser
   namespace: Regexp
   repo_uri: 'https://github.com/ammar/regexp_parser.git'
-  repo_ref: 'v0.4.3'
+  repo_ref: 'v0.4.4'
   ruby_glob_pattern: '**/*.rb'
   mutation_coverage: false
   mutation_generation: true

--- a/spec/support/warnings.yml
+++ b/spec/support/warnings.yml
@@ -2,4 +2,4 @@
 - 'lib/parallel.rb:222: warning: shadowing outer local variable - args'
 - 'lib/parallel.rb:227: warning: shadowing outer local variable - args'
 - 'lib/parser/lexer.rb:10922: warning: assigned but unused variable - testEof'
-- 'lib/regexp_parser/scanner.rb:1674: warning: assigned but unused variable - testEof'
+- 'lib/regexp_parser/scanner.rb:1675: warning: assigned but unused variable - testEof'


### PR DESCRIPTION
This version allows to run tests on Ruby 2.3.4.