### PR TITLE
Add mutation from class to module

### DIFF
--- a/lib/mutant/mutator/node/class.rb
+++ b/lib/mutant/mutator/node/class.rb
@@ -13,7 +13,15 @@ module Mutant
         #
         # @return [undefined]
         def dispatch
+          mutate_type
           emit_body_mutations if body
+        end
+
+        # Emit class -> type mutations
+        #
+        # @return [undefined]
+        def mutate_type
+          emit(s(:module, klass, body))
         end
       end # Class
     end # Node

--- a/meta/class.rb
+++ b/meta/class.rb
@@ -3,8 +3,17 @@ Mutant::Meta::Example.add :class do
 
   mutation 'class Foo; nil; end'
   mutation 'class Foo; self; end'
+  mutation 'module Foo; bar; end'
 end
 
 Mutant::Meta::Example.add :class do
   source 'class Foo; end'
+
+  mutation 'module Foo; end'
+end
+
+Mutant::Meta::Example.add :class do
+  source 'class Foo < Baz; end'
+
+  mutation 'module Foo; end'
 end


### PR DESCRIPTION
Mostly for util-like classes, something lile

```ruby
class FileNameSanitizer
  def self.call(file_name)
    file_name.gsub(/[^0-9A-Z]/i, '_')
  end
end
```

The main aim is not to change from class to module, but change way of using (initializers and so on)
