### PR TITLE
Add support for RSpec 3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       unparser (~> 0.2.5)
     mutant-rspec (0.8.14)
       mutant (~> 0.8.14)
-      rspec-core (>= 3.4.0, < 3.7.0)
+      rspec-core (>= 3.4.0, < 3.8.0)
 
 GEM
   remote: https://rubygems.org/

--- a/mutant-rspec.gemspec
+++ b/mutant-rspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[LICENSE]
 
   gem.add_runtime_dependency('mutant', "~> #{gem.version}")
-  gem.add_runtime_dependency('rspec-core', '>= 3.4.0', '< 3.7.0')
+  gem.add_runtime_dependency('rspec-core', '>= 3.4.0', '< 3.8.0')
 
   gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
 end

--- a/spec/integration/mutant/rspec_spec.rb
+++ b/spec/integration/mutant/rspec_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'rspec integration', mutant: false do
 
   let(:base_cmd) { 'bundle exec mutant -I lib --require test_app --use rspec' }
 
-  %w[3.4 3.5 3.6].each do |version|
+  %w[3.4 3.5 3.6 3.7].each do |version|
     context "RSpec #{version}" do
       let(:gemfile) { "Gemfile.rspec#{version}" }
 

--- a/test_app/Gemfile.rspec3.7
+++ b/test_app/Gemfile.rspec3.7
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gem 'rspec',      '~> 3.7.0'
+gem 'rspec-core', '~> 3.7.0'
+gem 'mutant',       path: '../'
+gem 'mutant-rspec', path: '../'
+gem 'adamantium'
+eval_gemfile File.expand_path('../../Gemfile.shared', __FILE__)


### PR DESCRIPTION
This PR updates the RSpec dependency to allow RSpec`< 3.8.0`