### PR TITLE
Add exclude support to Corpus and fix 'literal contains escape sequences incompatible with UTF-8' Corpus failure

### DIFF
--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -15,6 +15,9 @@
       - language/regexp/interpolation_spec.rb
     '#<Regexp::Scanner::PrematureEndError: Premature end of pattern at \xA>':
       - language/regexp/escapes_spec.rb
+  exclude:
+    - core/string/casecmp_spec.rb
+    - core/symbol/casecmp_spec.rb
 - name: regexp_parser
   namespace: Regexp
   repo_uri: 'https://github.com/ammar/regexp_parser.git'
@@ -25,6 +28,7 @@
   expected_errors:
     "Regexp::Syntax::Ruby::V233 does not implement: [escape:codepoint]":
      - regexp_parser/test/parser/test_escapes.rb
+  exclude: []
 - name: auom
   namespace: AUOM
   repo_uri: 'https://github.com/mbj/auom.git'
@@ -33,6 +37,7 @@
   mutation_coverage: true
   mutation_generation: true
   expected_errors: {}
+  exclude: []
 - name: axiom
   namespace: Axiom
   repo_uri: 'https://github.com/dkubb/axiom.git'
@@ -41,3 +46,4 @@
   mutation_coverage: false
   mutation_generation: true
   expected_errors: {}
+  exclude: []

--- a/spec/support/corpus.rb
+++ b/spec/support/corpus.rb
@@ -38,7 +38,8 @@ module MutantSpec
         :namespace,
         :repo_uri,
         :repo_ref,
-        :ruby_glob_pattern
+        :ruby_glob_pattern,
+        :exclude
       )
 
       # Verify mutation coverage
@@ -175,6 +176,7 @@ module MutantSpec
           .glob(repo_path.join(ruby_glob_pattern))
           .sort_by(&:size)
           .reverse
+          .reject { |path| exclude.include?(path.relative_path_from(repo_path).to_s) }
       end
 
       # Number of parallel processes to use
@@ -320,7 +322,8 @@ module MutantSpec
                         ->(hash) { hash.map { |key, values| [key, values.map(&Pathname.method(:new))] }.to_h },
                         ->(hash) { hash.map { |key, values| [key, values.map(&:to_s)]                 }.to_h }
                       ]),
-                    s(:load_attribute_hash, s(:param, ErrorWhitelist))))),
+                    s(:load_attribute_hash, s(:param, ErrorWhitelist)))),
+                s(:key_symbolize, :exclude, s(:map, s(:guard, s(:primitive, String))))),
               s(:anima_load, Project))))
       end
 


### PR DESCRIPTION
This pull request adds exclude support to corpus and fixes the following Corpus failure:
```bash
Mutant on ruby corpus rubyspec does not fail on mutation generation
     Failure/Error: node = Parser::CurrentRuby.parse(path.read)
     
     Parser::SyntaxError:
       literal contains escape sequences incompatible with UTF-8
```