### PR TITLE
Bump rspec dependency to cover all future 3.x releases

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v0.8.16 2018-08-03
+
+* Support for rspec-3.x
+
 # v0.8.15 2018-07-17
 
 * Fix boot time issue

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -1,4 +1,4 @@
 module Mutant
   # Current mutant version
-  VERSION = '0.8.15'.freeze
+  VERSION = '0.8.16'.freeze
 end # Mutant

--- a/mutant-rspec.gemspec
+++ b/mutant-rspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[LICENSE]
 
   gem.add_runtime_dependency('mutant', "~> #{gem.version}")
-  gem.add_runtime_dependency('rspec-core', '>= 3.4.0', '< 3.8.0')
+  gem.add_runtime_dependency('rspec-core', '>= 3.4.0', '< 4.0.0')
 
   gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
 end

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -18,6 +18,8 @@
   exclude:
     - core/string/casecmp_spec.rb
     - core/symbol/casecmp_spec.rb
+    - language/source_encoding_spec.rb
+    - security/cve_2010_1330_spec.rb
 - name: regexp_parser
   namespace: Regexp
   repo_uri: 'https://github.com/ammar/regexp_parser.git'


### PR DESCRIPTION
Background:

* We hook deep into RSpec internals to get very fine grained test
  selection
* These APIs are NOT public.
* Hence mutant was always very restrictive in its versioning, to not
  whitelist a version where these internals are eventually changed.
* No such change happened in years.

Conclusion:

* The past approach of whitelisting rspec version after rspec version is
  not the correct choice for reducing the mutant maintainership
  workload.
* We'll eat the potential regression over not automatically covering new
  rspec releases in the 3.x series (yeah, I know potentially last famous words).