### PR TITLE
Change fail fast computation to reduce scope

### DIFF
--- a/lib/mutant/result.rb
+++ b/lib/mutant/result.rb
@@ -108,6 +108,14 @@ module Mutant
         env.subjects.length
       end
 
+      # Test if processing needs to stop
+      #
+      # @return [Boolean]
+      #
+      def stop?
+        env.config.fail_fast && !subject_results.all?(&:success?)
+      end
+
     end # Env
 
     # Test result

--- a/lib/mutant/runner/sink.rb
+++ b/lib/mutant/runner/sink.rb
@@ -29,7 +29,7 @@ module Mutant
       #
       # @return [Boolean]
       def stop?
-        env.config.fail_fast && !status.subject_results.all?(&:success?)
+        status.stop?
       end
 
       # Handle mutation finish


### PR DESCRIPTION
* All state to compute #stop? is available on the result already, there
  is no need to peek into the structure from the outside.