### PR TITLE
Improve isolation error detection

### DIFF
--- a/lib/mutant/isolation.rb
+++ b/lib/mutant/isolation.rb
@@ -9,8 +9,18 @@ module Mutant
     class Result
       include AbstractType, Adamantium
 
-      abstract_method :value
       abstract_method :error
+      abstract_method :next
+      abstract_method :value
+
+      # Add error on top of current result
+      #
+      # @param [Result] error
+      #
+      # @return [Result]
+      def add_error(error)
+        ErrorChain.new(error, self)
+      end
 
       # Test for success
       #
@@ -28,6 +38,11 @@ module Mutant
       class Exception < self
         include Concord::Public.new(:value)
       end # Error
+
+      # Result when there where many results
+      class ErrorChain < Result
+        include Concord::Public.new(:value, :next)
+      end # ChainError
     end # Result
 
     # Call block in isolation

--- a/spec/unit/mutant/isolation/result_spec.rb
+++ b/spec/unit/mutant/isolation/result_spec.rb
@@ -24,4 +24,18 @@ RSpec.describe Mutant::Isolation::Result do
       end
     end
   end
+
+  describe 'add_error' do
+    let(:other)  { described_class::Success.new(object) }
+    let(:value)  { double('Object')                     }
+    let(:object) { described_class::Success.new(value)  }
+
+    def apply
+      object.add_error(other)
+    end
+
+    it 'returns chain instance' do
+      expect(apply).to eql(described_class::ErrorChain.new(other, object))
+    end
+  end
 end

--- a/spec/unit/mutant/reporter/cli/printer/isolation_result_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/isolation_result_spec.rb
@@ -70,5 +70,55 @@ RSpec.describe Mutant::Reporter::CLI::Printer::IsolationResult do
         * Reduce locks
       STR
     end
+
+    context 'on child isolation error' do
+      let(:reportable) do
+        Mutant::Isolation::Fork::ChildError.new(
+          instance_double(
+            Process::Status,
+            'unsuccessful status'
+          )
+        )
+      end
+
+      it_reports <<~'STR'
+        Killfork exited nonzero. Its result (if any) was ignored:
+        #<InstanceDouble(Process::Status) "unsuccessful status">
+      STR
+    end
+
+    context 'on child isolation error' do
+      let(:fork_error) do
+        Mutant::Isolation::Fork::ForkError.new
+      end
+
+      let(:child_error) do
+        Mutant::Isolation::Fork::ChildError.new(
+          instance_double(
+            Process::Status,
+            'unsuccessful status'
+          )
+        )
+      end
+
+      let(:reportable) do
+        Mutant::Isolation::Result::ErrorChain.new(
+          fork_error,
+          child_error
+        )
+      end
+
+      it_reports <<~'STR'
+        Forking the child process to isolate the mutation in failed.
+        This meant that the either the RubyVM or your OS was under
+        too much pressure to add another child process.
+
+        Possible solutions are:
+        * Reduce concurrency
+        * Reduce locks
+        Killfork exited nonzero. Its result (if any) was ignored:
+        #<InstanceDouble(Process::Status) "unsuccessful status">
+      STR
+    end
   end
 end


### PR DESCRIPTION
Related to #802, first making it runtime detectable before fixing.


* It makes no sense to assume that all errors are exceptions
* This would force us to raise exceptions just to produce errors, at
  control flow stages we could just return a more specialized error
  instance