### PR TITLE
Remove contribution 1df1541cd6f5462b68dc83942aa8ee33c03e8052

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ Credits
 -------
 
 * [Markus Schirp (mbj)](https://github.com/mbj)
-* A gist, now removed, from [dkubb](https://github.com/dkubb) showing ideas.
 * Older abandoned [mutant](https://github.com/txus/mutant). For motivating me doing this one.
 * [heckle](https://github.com/seattlerb/heckle). For getting me into mutation testing.
 


### PR DESCRIPTION
* Removes contribution stonecypher@gmail.com:1df1541cd6f5462b68dc83942aa8ee33c03e8052
* A reference to a removed gist is not really helpful.