### PR TITLE
Fix def example to tag for arg mutation

### DIFF
--- a/meta/def.rb
+++ b/meta/def.rb
@@ -107,7 +107,7 @@ Mutant::Meta::Example.add :def do
   mutation 'def foo(a, b = nil); super; end'
 end
 
-Mutant::Meta::Example.add :def do
+Mutant::Meta::Example.add :def, :arg do
   source 'def foo(_unused); end'
 
   mutation 'def foo(_unused); raise; end'


### PR DESCRIPTION
* There is no dedicated arg spec, and if we want to associate the
  underscore semantics we have to mark it explicitly.