### PR TITLE
Change rubocop block length metric excludes

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -111,7 +111,9 @@ Metrics/AbcSize:
   Max: 21.02
 
 Metrics/BlockLength:
-  Enabled: false
+  Exclude:
+  - 'spec/**/*.rb'
+  - 'mutant.gemspec'
 
 # Buggy cop, returns false positive for our code base
 NonLocalExitFromIterator:

--- a/meta/case.rb
+++ b/meta/case.rb
@@ -31,6 +31,7 @@ Mutant::Meta::Example.add :case do
   RUBY
 end
 
+# rubocop:disable Metric/BlockLength
 Mutant::Meta::Example.add :case do
   source <<-RUBY
     case condition


### PR DESCRIPTION
* No need to globally disable it
* Be more specific