### PR TITLE
Fix source location blacklist to be more accurate

### DIFF
--- a/lib/mutant/matcher/method.rb
+++ b/lib/mutant/matcher/method.rb
@@ -8,9 +8,8 @@ module Mutant
               Adamantium::Flat,
               Concord::Public.new(:scope, :target_method, :evaluator)
 
-      # Methods within rbx kernel directory are precompiled and their source
-      # cannot be accessed via reading source location. Same for methods created by eval.
-      BLACKLIST = %r{\A(kernel/|\(eval\)\z)}.freeze
+      # Source locations we cannot acces
+      BLACKLIST = %w[(eval) <internal:prelude>].to_set.freeze
 
       SOURCE_LOCATION_WARNING_FORMAT =
         '%s does not have a valid source location, unable to emit subject'
@@ -55,7 +54,7 @@ module Mutant
         # @return [Truthy]
         def skip?
           location = source_location
-          if location.nil? || BLACKLIST.match(location.first)
+          if location.nil? || BLACKLIST.include?(location.first)
             env.warn(SOURCE_LOCATION_WARNING_FORMAT % target_method)
           elsif matched_node_path.any?(&method(:n_block?))
             env.warn(CLOSURE_WARNING_FORMAT % target_method)

--- a/spec/unit/mutant/warning_filter_spec.rb
+++ b/spec/unit/mutant/warning_filter_spec.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Mutant::WarningFilter do
-  before do
-    if RUBY_ENGINE.eql?('rbx')
-      skip 'Disabled because expected warnings are from MRI'
-    end
-  end
-
   let(:object) { described_class.new(target) }
 
   let(:target) do


### PR DESCRIPTION
* The `kernel/` prefix was RBX specific, and we can remove it now.
* The `<intenal:prelude>` is MRI specific an we have to add it.