### PR TITLE
Correct typos in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ On each detection of uncovered semantics you have the opportunity to:
 ## How Do I use it?
 
 * Start with reading the [nomenclature](/docs/nomenclature.md) documentation.
-* Than select and setup your [integration](/docs/nomenclature.md#interation), also make sure
+* Then select and setup your [integration](/docs/nomenclature.md#integration), also make sure
   you can reproduce the examples in the integration specific documentation.
-* Identify your preferred mutation testing strategy. Its recommended to start at the commit level,
+* Identify your preferred mutation testing strategy. It is recommended to start at the commit level,
   to test only the code you had been touching. See the [incremental](#only-mutating-changed-code)
   mutation testing documentation.
 


### PR DESCRIPTION
Fixing some minor typos, including the link to the integration setup.