### PR TITLE
Change gemspec to require parser=2.6.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ PATH
       ice_nine (~> 0.11.1)
       memoizable (~> 0.4.2)
       mutant-license (~> 0.1.0)
+      parser (= 2.6.3)
       procto (~> 0.0.2)
       unparser (~> 0.4.5)
 

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('ice_nine',       '~> 0.11.1')
   gem.add_runtime_dependency('memoizable',     '~> 0.4.2')
   gem.add_runtime_dependency('mutant-license', '~> 0.1.0')
+  gem.add_runtime_dependency('parser',         '=  2.6.3')
   gem.add_runtime_dependency('procto',         '~> 0.0.2')
   gem.add_runtime_dependency('unparser',       '~> 0.4.5')
 

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -13,6 +13,7 @@
     - core/module/fixtures/autoload_never_set.rb
     - core/module/fixtures/path2/load_path.rb
     - core/string/casecmp_spec.rb
+    - core/string/encode_spec.rb
     - core/string/shared/to_sym.rb
     - core/symbol/casecmp_spec.rb
     - language/fixtures/freeze_magic_comment_required_diff_enc.rb


### PR DESCRIPTION
Extraction from #973

The motivation for this change is to get CI green. The details behind that are layed down in the commit message.

### Acceptance

* [x] Green CI