### PR TITLE
Fix a warning due to an unset ivar

### DIFF
--- a/lib/mutant/minitest/coverage.rb
+++ b/lib/mutant/minitest/coverage.rb
@@ -20,7 +20,9 @@ module Mutant
       #
       # @api public
       def cover(expression)
-        fail "#{self} already declares to cover: #{@covers}" if @covers
+        if defined?(@cover_expression) && @cover_expression
+          fail "#{self} already declares to cover: #{@cover_expression}"
+        end
 
         @cover_expression = expression
       end


### PR DESCRIPTION
It looks like the instance variable name here was changed at some point
during the design and that the check/warn is now looking at the
incorrect variable, resulting in a warning for a use of an unset
instance variable.