### PR TITLE
Change to generic catch all node mutator

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v0.9.8
+
+* Change to generic catch all node mutator. This allows better cross parser version compatibility.
+
 # v0.9.7 2020-07-22
 
 * Bump parser dependency to 2.7.1, note this still does not support Ruby 2.7 syntax.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.9.6)
+    mutant (0.9.7)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)

--- a/lib/mutant/mutator/node/generic.rb
+++ b/lib/mutant/mutator/node/generic.rb
@@ -3,79 +3,8 @@
 module Mutant
   class Mutator
     class Node
-
       # Generic mutator
       class Generic < self
-
-        unsupported_nodes = %i[
-          __FILE__
-          __LINE__
-          alias
-          arg_expr
-          array_pattern
-          array_pattern_with_tail
-          back_ref
-          blockarg
-          blockarg_expr
-          case_match
-          complex
-          const_pattern
-          def_e
-          defs_e
-          eflipflop
-          empty
-          empty_else
-          ensure
-          find_pattern
-          for
-          forward_arg
-          forward_args
-          forwarded_args
-          hash_pattern
-          ident
-          if_guard
-          iflipflop
-          in_match
-          in_pattern
-          kwnilarg
-          kwrestarg
-          kwsplat
-          match_alt
-          match_as
-          match_nil_pattern
-          match_rest
-          match_var
-          match_with_lvasgn
-          match_with_trailing_comma
-          module
-          mrasgn
-          numargs
-          numblock
-          objc_kwarg
-          objc_restarg
-          objc_varargs
-          pin
-          postexe
-          preexe
-          rasgn
-          rational
-          redo
-          restarg
-          restarg_expr
-          retry
-          root
-          sclass
-          shadowarg
-          undef
-          unless_guard
-          until_post
-          while_post
-          xstr
-        ]
-
-        # These nodes still need a dedicated mutator,
-        # your contribution is that close!
-        handle(*unsupported_nodes)
 
       private
 

--- a/lib/mutant/registry.rb
+++ b/lib/mutant/registry.rb
@@ -32,14 +32,9 @@ module Mutant
     #
     # @param [Symbol] type
     #
-    # @return [Class]
-    #
-    # @raise [ArgumentError]
-    #   raises argument error when class cannot be found
+    # @return [Class<Mutator>]
     def lookup(type)
-      contents.fetch(type) do
-        fail RegistryError, "No entry for: #{type.inspect}"
-      end
+      contents.fetch(type, Mutator::Node::Generic)
     end
 
   end # Registry

--- a/spec/unit/mutant/registry_spec.rb
+++ b/spec/unit/mutant/registry_spec.rb
@@ -1,47 +1,74 @@
 # frozen_string_literal: true
 
 RSpec.describe Mutant::Registry do
-  let(:lookup)  { object.lookup(type)           }
-  let(:object)  { described_class.new           }
   let(:mutator) { class_double(Mutant::Mutator) }
+  let(:object)  { described_class.new           }
 
-  def register_mutator
-    object.register(type, mutator)
-  end
+  describe '#lookup' do
+    subject { object.lookup(type) }
 
-  context 'on registered type' do
-    subject { register_mutator }
-
-    let(:type) { :true }
-
-    before { subject }
-
-    it 'returns registered mutator' do
-      expect(lookup).to be(mutator)
+    def register
+      object.register(type, mutator)
     end
 
-    it_behaves_like 'a command method'
+    context 'on known type' do
+      let(:type) { :true }
 
-    context 'when registered twice' do
-      it 'fails upon registration' do
-        expect { register_mutator }.to raise_error(described_class::RegistryError, 'Duplicate type registration: :true')
+      it 'returns registered' do
+        register
+        expect(subject).to be(mutator)
+      end
+    end
+
+    context 'on unknown type' do
+      let(:type) { :unknown }
+
+      it 'returns genericm mutator' do
+        expect(subject).to be(Mutant::Mutator::Node::Generic)
       end
     end
   end
 
-  context 'on unknown type' do
-    let(:type) { :unknown }
+  describe '#register' do
+    subject { object.register(type, mutator) }
 
-    it 'raises error' do
-      expect { lookup }.to raise_error(described_class::RegistryError, 'No entry for: :unknown')
+    def lookup
+      subject.lookup(type)
     end
-  end
 
-  context 'when registering an invalid node type' do
-    let(:type) { :invalid }
+    context 'on registered type' do
+      let(:type) { :true }
 
-    it 'raises error' do
-      expect { register_mutator }.to raise_error(described_class::RegistryError, 'Invalid type registration: :invalid')
+      it_behaves_like 'a command method'
+
+      it 'allows to lookup the mutator' do
+        subject
+        expect(lookup).to be(mutator)
+      end
+
+      context 'when registering twice' do
+        it 'fails upon registration' do
+          object.register(type, mutator)
+
+          expect { subject }
+            .to raise_error(
+              described_class::RegistryError,
+              'Duplicate type registration: :true'
+            )
+        end
+      end
+    end
+
+    context 'when registering an invalid node type' do
+      let(:type) { :invalid }
+
+      it 'raises error' do
+        expect { subject }
+          .to raise_error(
+            described_class::RegistryError,
+            'Invalid type registration: :invalid'
+          )
+      end
     end
   end
 end


### PR DESCRIPTION
* Before this commit mutant tried to cover each node type the parser gem
  may return explicitly.
* This was very useful during the pre 2.6 times when the Ruby syntax and
  the parser gem had a more stable node type set to deal with.
* In recent years Ruby sadly adds lots of syntax, which means mutant
  will face parser versions it was not explicitly tested with.
* This change allows mutant to co exist with any node type in the
  future, while it may not do anything useful for these node types.

[Fix #1007]