### PR TITLE
Remove boolean -> `nil` mutations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Remove `true` -> `nil` and `false` -> `nil` mutations. [#1018](https://github.com/mbj/mutant/pull/1018)
+
 # v0.9.8 2020-08-02
 
 * Change to generic catch all node mutator. This allows better cross parser version compatibility.

--- a/lib/mutant/mutator/node/literal/boolean.rb
+++ b/lib/mutant/mutator/node/literal/boolean.rb
@@ -20,7 +20,6 @@ module Mutant
           #
           # @return [undefined]
           def dispatch
-            emit_nil
             emit(s(MAP.fetch(node.type)))
           end
 

--- a/meta/and.rb
+++ b/meta/and.rb
@@ -7,8 +7,6 @@ Mutant::Meta::Example.add :and do
   mutation 'true'
   mutation 'false'
   mutation 'true or false'
-  mutation 'true and nil'
-  mutation 'nil and false'
   mutation 'false and false'
   mutation 'true and true'
   mutation '!true and false'

--- a/meta/array.rb
+++ b/meta/array.rb
@@ -6,7 +6,6 @@ Mutant::Meta::Example.add :array do
   singleton_mutations
   mutation 'true'
   mutation '[false]'
-  mutation '[nil]'
   mutation '[]'
 end
 
@@ -16,9 +15,7 @@ Mutant::Meta::Example.add :array do
   singleton_mutations
 
   # Mutation of each element in array
-  mutation '[nil, false]'
   mutation '[false, false]'
-  mutation '[true, nil]'
   mutation '[true, true]'
 
   # Remove each element of array once

--- a/meta/begin.rb
+++ b/meta/begin.rb
@@ -6,8 +6,6 @@ Mutant::Meta::Example.add :begin do
   # Mutation of each statement in block
   mutation 'true; true'
   mutation 'false; false'
-  mutation 'nil; false'
-  mutation 'true; nil'
 
   # Delete each statement
   mutation 'true'
@@ -18,6 +16,5 @@ Mutant::Meta::Example.add :begin do
 
   source s(:begin, s(:true))
   # Mutation of each statement in block
-  mutation s(:begin, s(:nil))
   mutation s(:begin, s(:false))
 end

--- a/meta/block.rb
+++ b/meta/block.rb
@@ -108,7 +108,6 @@ Mutant::Meta::Example.add :block do
 
   singleton_mutations
   mutation 'foo { self << false }'
-  mutation 'foo { self << nil }'
   mutation 'foo { nil << true }'
   mutation 'foo { nil }'
   mutation 'foo { self }'
@@ -134,7 +133,6 @@ Mutant::Meta::Example.add :block do
   mutation 'foo { break if true }'
   mutation 'foo { next if !true }'
   mutation 'foo { next if false }'
-  mutation 'foo { next if nil }'
   mutation 'foo { next }'
 end
 
@@ -163,7 +161,6 @@ Mutant::Meta::Example.add :block do
   mutation 'foo { nil if true }'
   mutation 'foo { break if !true }'
   mutation 'foo { break if false }'
-  mutation 'foo { break if nil }'
   mutation 'foo { break }'
 end
 

--- a/meta/break.rb
+++ b/meta/break.rb
@@ -5,6 +5,5 @@ Mutant::Meta::Example.add :break do
 
   singleton_mutations
   mutation 'break false'
-  mutation 'break nil'
   mutation 'break'
 end

--- a/meta/case.rb
+++ b/meta/case.rb
@@ -23,12 +23,6 @@ Mutant::Meta::Example.add :case do
     else
     end
   RUBY
-  mutation <<-RUBY
-    case
-    when nil
-    else
-    end
-  RUBY
 end
 
 # rubocop:disable Metrics/BlockLength

--- a/meta/casgn.rb
+++ b/meta/casgn.rb
@@ -5,7 +5,6 @@ Mutant::Meta::Example.add :casgn do
 
   mutation 'A__MUTANT__ = true'
   mutation 'A = false'
-  mutation 'A = nil'
   mutation 'remove_const :A'
 end
 
@@ -14,7 +13,6 @@ Mutant::Meta::Example.add :casgn do
 
   mutation 'self::A__MUTANT__ = true'
   mutation 'self::A = false'
-  mutation 'self::A = nil'
   mutation 'self.remove_const :A'
 end
 
@@ -24,5 +22,4 @@ Mutant::Meta::Example.add :casgn do
   singleton_mutations
   mutation 'A__MUTANT__ &&= true'
   mutation 'A &&= false'
-  mutation 'A &&= nil'
 end

--- a/meta/cvasgn.rb
+++ b/meta/cvasgn.rb
@@ -6,5 +6,4 @@ Mutant::Meta::Example.add :cvasgn do
   singleton_mutations
   mutation '@@a__mutant__ = true'
   mutation '@@a = false'
-  mutation '@@a = nil'
 end

--- a/meta/def.rb
+++ b/meta/def.rb
@@ -56,8 +56,6 @@ Mutant::Meta::Example.add :def do
   # Mutation of each statement in block
   mutation 'def foo; true; true; end'
   mutation 'def foo; false; false; end'
-  mutation 'def foo; true; nil; end'
-  mutation 'def foo; nil; false; end'
 
   # Remove statement in block
   mutation 'def foo; true; end'
@@ -97,7 +95,6 @@ Mutant::Meta::Example.add :def do
   mutation 'def foo(a, b = nil); end'
   mutation 'def foo; true; end'
   mutation 'def foo(a, b = nil); raise; end'
-  mutation 'def foo(a, b = nil); nil; end'
   mutation 'def foo(a, b = nil); false; end'
   mutation 'def foo(a); true; end'
   mutation 'def foo(a, b = nil); b = nil; true; end'
@@ -118,7 +115,6 @@ end
 Mutant::Meta::Example.add :def do
   source 'def foo(_unused = true); end'
 
-  mutation 'def foo(_unused = nil); end'
   mutation 'def foo(_unused = false); end'
   mutation 'def foo(_unused = true); raise; end'
   mutation 'def foo(_unused); end'
@@ -154,7 +150,6 @@ Mutant::Meta::Example.add :def do
   mutation 'def foo(a); end'
   mutation 'def foo(); end'
   mutation 'def foo(a = false); end'
-  mutation 'def foo(a = nil); end'
   mutation 'def foo(_a = true); end'
   mutation 'def foo(a = true); raise; end'
   mutation 'def foo(a = true); a = true; end'
@@ -167,8 +162,6 @@ Mutant::Meta::Example.add :def do
   # Body presence mutation
   mutation 'def self.foo; false; false; end'
   mutation 'def self.foo; true; true; end'
-  mutation 'def self.foo; true; nil; end'
-  mutation 'def self.foo; nil; false; end'
 
   # Body presence mutation
   mutation 'def self.foo; true; end'

--- a/meta/ensure.rb
+++ b/meta/ensure.rb
@@ -5,5 +5,4 @@ Mutant::Meta::Example.add :ensure do
 
   singleton_mutations
   mutation 'begin; rescue; ensure; false; end'
-  mutation 'begin; rescue; ensure; nil; end'
 end

--- a/meta/false.rb
+++ b/meta/false.rb
@@ -3,6 +3,5 @@
 Mutant::Meta::Example.add :false do
   source 'false'
 
-  mutation 'nil'
   mutation 'true'
 end

--- a/meta/gvasgn.rb
+++ b/meta/gvasgn.rb
@@ -6,5 +6,4 @@ Mutant::Meta::Example.add :gvasgn do
   singleton_mutations
   mutation '$a__mutant__ = true'
   mutation '$a = false'
-  mutation '$a = nil'
 end

--- a/meta/hash.rb
+++ b/meta/hash.rb
@@ -7,13 +7,9 @@ Mutant::Meta::Example.add :hash do
 
   # Mutation of each key and value in hash
   mutation '{ false => true  ,  false => false }'
-  mutation '{ nil   => true  ,  false => false }'
   mutation '{ true  => false ,  false => false }'
-  mutation '{ true  => nil   ,  false => false }'
   mutation '{ true  => true  ,  true  => false }'
-  mutation '{ true  => true  ,  nil   => false }'
   mutation '{ true  => true  ,  false => true  }'
-  mutation '{ true  => true  ,  false => nil   }'
 
   # Remove each key once
   mutation '{ true => true }'

--- a/meta/if.rb
+++ b/meta/if.rb
@@ -28,11 +28,9 @@ Mutant::Meta::Example.add :if do
 
   # mutation of if body
   mutation 'if condition; false; else false; end'
-  mutation 'if condition; nil;   else false; end'
 
   # mutation of else body
   mutation 'if condition; true;  else true;  end'
-  mutation 'if condition; true;  else nil;   end'
 end
 
 Mutant::Meta::Example.add :if do
@@ -41,7 +39,6 @@ Mutant::Meta::Example.add :if do
   singleton_mutations
   mutation 'if !condition; true;  end'
   mutation 'if condition;  false; end'
-  mutation 'if condition;  nil;   end'
   mutation 'if true;       true;  end'
   mutation 'if false;      true;  end'
   mutation 'if nil;        true;  end'
@@ -57,7 +54,6 @@ Mutant::Meta::Example.add :if do
   mutation 'unless true;       true;  end'
   mutation 'unless false;      true;  end'
   mutation 'unless condition;  false; end'
-  mutation 'unless condition;  nil;   end'
   mutation 'if     condition;  true;  end'
   mutation 'true'
 end
@@ -68,7 +64,6 @@ Mutant::Meta::Example.add :if do
   singleton_mutations
   mutation 'false if /foo/'
   mutation 'true if //'
-  mutation 'nil if /foo/'
   mutation 'true if true'
   mutation 'true if false'
   mutation 'true if nil'

--- a/meta/ivasgn.rb
+++ b/meta/ivasgn.rb
@@ -6,7 +6,6 @@ Mutant::Meta::Example.add :ivasgn do
   singleton_mutations
   mutation '@a__mutant__ = true'
   mutation '@a = false'
-  mutation '@a = nil'
 end
 
 Mutant::Meta::Example.add :ivasgn do

--- a/meta/kwbegin.rb
+++ b/meta/kwbegin.rb
@@ -5,5 +5,4 @@ Mutant::Meta::Example.add :kwbegin do
 
   singleton_mutations
   mutation 'begin; false; end'
-  mutation 'begin; nil; end'
 end

--- a/meta/lvasgn.rb
+++ b/meta/lvasgn.rb
@@ -6,7 +6,6 @@ Mutant::Meta::Example.add :lvasgn do
   singleton_mutations
   mutation 'a__mutant__ = true'
   mutation 'a = false'
-  mutation 'a = nil'
 end
 
 Mutant::Meta::Example.add :array, :lvasgn do

--- a/meta/match_current_line.rb
+++ b/meta/match_current_line.rb
@@ -6,7 +6,6 @@ Mutant::Meta::Example.add :match_current_line do
   singleton_mutations
   mutation 'false if /foo/'
   mutation 'true if //'
-  mutation 'nil if /foo/'
   mutation 'true if true'
   mutation 'true if false'
   mutation 'true if nil'

--- a/meta/next.rb
+++ b/meta/next.rb
@@ -5,7 +5,6 @@ Mutant::Meta::Example.add :next do
 
   singleton_mutations
   mutation 'next false'
-  mutation 'next nil'
   mutation 'next'
   mutation 'break true'
 end

--- a/meta/or.rb
+++ b/meta/or.rb
@@ -6,9 +6,7 @@ Mutant::Meta::Example.add :or do
   singleton_mutations
   mutation 'true'
   mutation 'false'
-  mutation 'nil or false'
   mutation 'false or false'
-  mutation 'true or nil'
   mutation 'true or true'
   mutation 'true and false'
   mutation '!true or false'

--- a/meta/regexp.rb
+++ b/meta/regexp.rb
@@ -58,7 +58,6 @@ Mutant::Meta::Example.add :regexp do
 
   singleton_mutations
   mutation 'false if /foo/'
-  mutation 'nil if /foo/'
   mutation 'true if true'
   mutation 'true if false'
   mutation 'true if nil'

--- a/meta/rescue.rb
+++ b/meta/rescue.rb
@@ -8,7 +8,6 @@ Mutant::Meta::Example.add :rescue do
   mutation 'begin; rescue self, ExceptionB => error; true; end'
   mutation 'begin; rescue ExceptionA, self => error; true; end'
   mutation 'begin; rescue ExceptionA, ExceptionB => error; false; end'
-  mutation 'begin; rescue ExceptionA, ExceptionB => error; nil; end'
   mutation 'begin; true; end'
 
 end
@@ -19,7 +18,6 @@ Mutant::Meta::Example.add :rescue do
   singleton_mutations
   mutation 'begin; rescue SomeException; true; end'
   mutation 'begin; rescue SomeException => error; false; end'
-  mutation 'begin; rescue SomeException => error; nil; end'
   mutation 'begin; rescue self => error; true; end'
   mutation 'begin; true; end'
 end
@@ -29,7 +27,6 @@ Mutant::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; rescue => error; false; end'
-  mutation 'begin; rescue => error; nil; end'
   mutation 'begin; rescue; true; end'
   mutation 'begin; true; end'
 end
@@ -39,7 +36,6 @@ Mutant::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; rescue; false; end'
-  mutation 'begin; rescue; nil; end'
   mutation 'begin; true end'
 end
 
@@ -48,7 +44,6 @@ Mutant::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; false; end'
-  mutation 'begin; nil; end'
 end
 
 Mutant::Meta::Example.add :rescue do
@@ -86,5 +81,4 @@ Mutant::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; rescue; ensure; false; end'
-  mutation 'begin; rescue; ensure; nil; end'
 end

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -488,9 +488,7 @@ end
     mutation 'true'
     mutation 'false'
     mutation "false #{operator} false"
-    mutation "nil   #{operator} false"
     mutation "true  #{operator} true"
-    mutation "true  #{operator} nil"
   end
 end
 

--- a/meta/true.rb
+++ b/meta/true.rb
@@ -3,6 +3,5 @@
 Mutant::Meta::Example.add :true do
   source 'true'
 
-  mutation 'nil'
   mutation 'false'
 end

--- a/meta/until.rb
+++ b/meta/until.rb
@@ -8,7 +8,6 @@ Mutant::Meta::Example.add :until do
   mutation 'until true; foo; end'
   mutation 'until true; end'
   mutation 'until false; foo; bar; end'
-  mutation 'until nil; foo; bar; end'
   mutation 'until true; foo; nil; end'
   mutation 'until true; foo; self; end'
   mutation 'until true; nil; bar; end'

--- a/meta/while.rb
+++ b/meta/while.rb
@@ -10,7 +10,6 @@ Mutant::Meta::Example.add :while do
   mutation 'while true; foo; end'
   mutation 'while true; end'
   mutation 'while false; foo; bar; end'
-  mutation 'while nil;   foo; bar; end'
   mutation 'while true;  foo; nil; end'
   mutation 'while true;  nil; bar; end'
   mutation 'while true;  raise; end'
@@ -22,5 +21,4 @@ Mutant::Meta::Example.add :while do
   singleton_mutations
   mutation 'while true; raise; end'
   mutation 'while false; end'
-  mutation 'while nil; end'
 end

--- a/meta/yield.rb
+++ b/meta/yield.rb
@@ -5,6 +5,5 @@ Mutant::Meta::Example.add :yield do
 
   singleton_mutations
   mutation 'yield false'
-  mutation 'yield nil'
   mutation 'yield'
 end

--- a/spec/unit/mutant/meta/example_spec.rb
+++ b/spec/unit/mutant/meta/example_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Mutant::Meta::Example do
     )
   end
 
-  let(:file)           { 'foo/bar.rb'         }
-  let(:node)           { s(:true)             }
-  let(:mutation_nodes) { [s(:nil), s(:false)] }
+  let(:file)           { 'foo/bar.rb' }
+  let(:node)           { s(:true)     }
+  let(:mutation_nodes) { [s(:false)]  }
 
   let(:mutations) do
     mutation_nodes.map do |node|

--- a/spec/unit/mutant/mutator/node_spec.rb
+++ b/spec/unit/mutant/mutator/node_spec.rb
@@ -41,12 +41,7 @@ RSpec.describe Mutant::Mutator::Node do
     end
 
     specify do
-      expect(apply).to eql(
-        [
-          s(:and, s(:nil), s(:true)),
-          s(:and, s(:true), s(:nil))
-        ].to_set
-      )
+      expect(apply).to eql([s(:and, s(:nil), s(:true))].to_set)
     end
   end
 end


### PR DESCRIPTION
Removes the following mutations:
- `true` -> `nil`
- `false` -> `nil`

Rationale:
- Since `true` is already mutated to `false` and vice versa, we already have a truthiness change and `nil` does not provide anything else in that direction. It is very unlikely to get a mutation from mutating to `nil` that we do not get from inverting the boolean.
- `nil` is actually the less primitive construct and easier to misuse.
  - nil.methods - false.methods # => [:to_a, :to_i, :to_f, :to_h, :to_r, :rationalize, :to_c]
    This allows for more cases where a `nil` is somehow accidentally turned into an empty hash, array, 0 value, etc.
  - false.methods - nil.methods # => []
  - false.methods == true.methods # => true
- It forces `nil` to be present in cases that are extremely hard to assert (inside conditionals that do not return the boolean expression) or, even if they are possible to assert, it is often awkward to do so. As a motivating example I like to use hashes as an asserted case statement (ex: `if { 'confirmed' => true, 'denied' => false }.fetch(enum_value) ...` but `mutant` would force me to make the value of the `'denied'` key to `nil` which is not an improvement in semantics or readability and very difficult to assert if the result of that expression is never part of a public API.
- It also results in fewer mutations being generated which is beneficial for CI runs and faster local feedback loops.
- This change also has the slight side benefit of removing more code from `mutant` than it adds.

@mbj Let me know what you think. I figured it was probably easier to just go ahead an open a PR for discussion rather than create an issue since it was a fairly easy change to make.