### PR TITLE
Mutate Array(foo) -> [foo]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add new mutation of `Array(foo)` -> `[foo]` [#1039](https://github.com/mbj/mutant/pull/1039)
+
 # v0.9.11 2020-08-25
 
 * Remove mutation to equivalent semantics on endless ranges [#1036](https://github.com/mbj/mutant/pull/1036).

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -79,11 +79,22 @@ module Mutant
         end
 
         def emit_selector_specific_mutations
+          emit_array_mutation
           emit_const_get_mutation
           emit_integer_mutation
           emit_dig_mutation
           emit_double_negation_mutation
           emit_lambda_mutation
+        end
+
+        def emit_array_mutation
+          return unless selector.equal?(:Array) && possible_kernel_method?
+
+          emit(s(:array, *arguments))
+        end
+
+        def possible_kernel_method?
+          receiver.nil? || receiver.eql?(s(:const, nil, :Kernel))
         end
 
         def emit_receiver_selector_mutations

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -598,3 +598,39 @@ Mutant::Meta::Example.add :send do
   mutation 'foo(self)'
   mutation 'foo(nil)'
 end
+
+Mutant::Meta::Example.add :send do
+  source 'Array(a)'
+
+  singleton_mutations
+  mutation 'a'
+  mutation s(:send, nil, :Array)
+  mutation 'Array(nil)'
+  mutation 'Array(self)'
+  mutation '[a]'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'Kernel.Array(a)'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'Kernel'
+  mutation 'self.Array(a)'
+  mutation 'Kernel.Array'
+  mutation 'Kernel.Array(nil)'
+  mutation 'Kernel.Array(self)'
+  mutation '[a]'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.Array(a)'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'self.Array(a)'
+  mutation 'foo'
+  mutation 'foo.Array'
+  mutation 'foo.Array(nil)'
+  mutation 'foo.Array(self)'
+end


### PR DESCRIPTION
- See #172. While #172 was closed outright, I think the rationale behind closing it is incorrect since the generic mutation there does not cover the proposed case. The benefit of using `[foo]` over `Array(foo)` if you have only scalar values is that you are using the simpler/narrower tool.