### PR TITLE
Mutate dynamic send to static send

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add new mutation to mutate dynamic sends to static sends ({`foo.__send__(:bar)`, `foo.send(:bar)`, `foo.public_send(:bar)`} -> `foo.bar`) [#1040](https://github.com/mbj/mutant/pull/1040)
+
 # v0.9.11 2020-08-25
 
 * Remove mutation to equivalent semantics on endless ranges [#1036](https://github.com/mbj/mutant/pull/1036).

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -79,11 +79,24 @@ module Mutant
         end
 
         def emit_selector_specific_mutations
+          emit_static_send
           emit_const_get_mutation
           emit_integer_mutation
           emit_dig_mutation
           emit_double_negation_mutation
           emit_lambda_mutation
+        end
+
+        def emit_static_send
+          return unless %i[__send__ send public_send].include?(selector)
+
+          dynamic_selector, *actual_arguments = *arguments
+
+          return unless n_sym?(dynamic_selector)
+
+          method_name = AST::Meta::Symbol.new(dynamic_selector).name
+
+          emit(s(:send, receiver, method_name, *actual_arguments))
         end
 
         def emit_receiver_selector_mutations

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -308,6 +308,68 @@ Mutant::Meta::Example.add :send do
 end
 
 Mutant::Meta::Example.add :send do
+  source '__send__(:foo)'
+
+  singleton_mutations
+  mutation 'foo'
+  mutation '__send__'
+  mutation 'public_send(:foo)'
+  mutation ':foo'
+  mutation '__send__(nil)'
+  mutation '__send__(self)'
+  mutation '__send__(:foo__mutant__)'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.send(:bar)'
+
+  singleton_mutations
+  mutation 'foo.bar'
+  mutation 'foo.send'
+  mutation 'foo.__send__(:bar)'
+  mutation 'foo.public_send(:bar)'
+  mutation 'foo'
+  mutation ':bar'
+  mutation 'self.send(:bar)'
+  mutation 'foo.send(nil)'
+  mutation 'foo.send(self)'
+  mutation 'foo.send(:bar__mutant__)'
+end
+
+Mutant::Meta::Example.add :send do # rubocop:disable Metrics/BlockLength
+  source 'foo.public_send(:bar, 1, two: true, **kwargs, &block)'
+
+  singleton_mutations
+  mutation 'foo.bar(1, two: true, **kwargs, &block)'
+  mutation 'foo'
+  mutation 'self.public_send(:bar, 1, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send'
+  mutation 'foo.public_send(nil, 1, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(self, 1, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar__mutant__, 1, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(1, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, nil, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, self, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, 0, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, -1, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, 2, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, { two: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, 1, nil, &block)'
+  mutation 'foo.public_send(:bar, 1, self, &block)'
+  mutation 'foo.public_send(:bar, 1, {}, &block)'
+  mutation 'foo.public_send(:bar, 1, { nil => true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, 1, { self => true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, 1, { two__mutant__: true, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, 1, { two: false, **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, 1, { **kwargs }, &block)'
+  mutation 'foo.public_send(:bar, 1, { two: true, **nil }, &block)'
+  mutation 'foo.public_send(:bar, 1, { two: true, **self }, &block)'
+  mutation 'foo.public_send(:bar, 1, { two: true }, &block)'
+  mutation 'foo.public_send(:bar, 1, &block)'
+  mutation 'foo.public_send(:bar, 1, two: true, **kwargs)'
+end
+
+Mutant::Meta::Example.add :send do
   source 'foo.send(bar)'
 
   singleton_mutations


### PR DESCRIPTION
Mutates:
- `foo.__send__(:bar)` -> `foo.bar`
- `foo.send(:bar)` -> `foo.bar`
- `foo.public_send(:bar)` -> `foo.bar`

...and so on, including arguments.

Closes #732