### PR TITLE
Fix `rubocop` namespace warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,16 +7,16 @@ AllCops:
   TargetRubyVersion: 2.5
 
 # Avoid parameter lists longer than five parameters.
-ParameterLists:
+Metrics/ParameterLists:
   Max: 3
   CountKeywordArgs: true
 
 # Avoid more than `Max` levels of nesting.
-BlockNesting:
+Metrics/BlockNesting:
   Max: 3
 
 # Align with the style guide.
-CollectionMethods:
+Style/CollectionMethods:
   Enabled: true
   PreferredMethods:
     collect:  'map'
@@ -24,15 +24,15 @@ CollectionMethods:
     find:     'detect'
     find_all: 'select'
 
-AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Enabled: false
 
 # Limit line length
-LineLength:
+Layout/LineLength:
   Max: 120
 
 # Disable documentation checking until a class needs to be documented once
-Documentation:
+Style/Documentation:
   Enabled: false
 
 # Permit
@@ -44,47 +44,47 @@ Documentation:
 #     if foo or bar
 #       ...
 #     end
-AndOr:
+Style/AndOr:
   EnforcedStyle: conditionals
 
 # Do not favor modifier if/unless usage when you have a single-line body
-IfUnlessModifier:
+Style/IfUnlessModifier:
   Enabled: false
 
 # Allow case equality operator (in limited use within the specs)
-CaseEquality:
+Style/CaseEquality:
   Enabled: false
 
 # Constants do not always have to use SCREAMING_SNAKE_CASE
-ConstantName:
+Naming/ConstantName:
   Enabled: false
 
 # Not all trivial readers/writers can be defined with attr_* methods
-TrivialAccessors:
+Style/TrivialAccessors:
   Enabled: false
 
 # Allow empty lines around class body
-EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
 # Allow empty lines around module body
-EmptyLinesAroundModuleBody:
+Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 
 # Allow empty lines around block body
-EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
 # Allow multiple line operations to not require indentation
-MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Enabled: false
 
 # Prefer String#% over Kernel#sprintf
-FormatString:
+Style/FormatString:
   EnforcedStyle: percent
 
 # Use square brackets for literal Array objects
-PercentLiteralDelimiters:
+Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%':  '{}'
     '%i': '[]'
@@ -97,11 +97,11 @@ PercentLiteralDelimiters:
     '%x': ()
 
 # Use %i[...] for arrays of symbols
-SymbolArray:
+Style/SymbolArray:
   Enabled: true
 
 # Prefer #kind_of? over #is_a?
-ClassCheck:
+Style/ClassCheck:
   EnforcedStyle: kind_of?
 
 # Do not prefer double quotes to be used when %q or %Q is more appropriate
@@ -118,7 +118,7 @@ Metrics/BlockLength:
   - 'mutant.gemspec'
 
 # Buggy cop, returns false positive for our code base
-NonLocalExitFromIterator:
+Lint/NonLocalExitFromIterator:
   Enabled: false
 
 # To allow alignment of similar expressions we want to allow more than one
@@ -127,27 +127,27 @@ NonLocalExitFromIterator:
 # let(:a) { bar    + something }
 # let(:b) { foobar + something }
 #
-SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: false
 
 # We use parallel assignments with great success
-ParallelAssignment:
+Style/ParallelAssignment:
   Enabled: false
 
 # Allow additional specs
-ExtraSpacing:
+Layout/ExtraSpacing:
   AllowForAlignment: true
 
 # Buggy
-FormatParameterMismatch:
+Lint/FormatParameterMismatch:
   Enabled: false
 
 # Different preference
-SignalException:
+Style/SignalException:
   EnforcedStyle: semantic
 
 # Do not use `alias`
-Alias:
+Style/Alias:
   EnforcedStyle: prefer_alias_method
 
 # Do not waste my horizontal or vertical space
@@ -166,11 +166,11 @@ Layout/FirstArrayElementIndentation:
 #     some_receiver.foo
 #                  .bar
 #                  .baz
-MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
 # Prefer `public_send` and `__send__` over `send`
-Send:
+Style/Send:
   Enabled: true
 
 Layout/HashAlignment:

--- a/spec/unit/mutant/config_spec.rb
+++ b/spec/unit/mutant/config_spec.rb
@@ -96,11 +96,11 @@ RSpec.describe Mutant::Config do
             YAML
           end
 
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           let(:expected_message) do
             'mutant.yml/Mutant::Transform::Sequence/2/Mutant::Transform::Hash/["integration"]/String: Expected: String but got: TrueClass'
           end
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
 
           it 'returns expected error' do
             expect(apply) .to eql(Mutant::Either::Left.new(expected_message))

--- a/spec/unit/mutant/reporter/cli_spec.rb
+++ b/spec/unit/mutant/reporter/cli_spec.rb
@@ -115,9 +115,9 @@ RSpec.describe Mutant::Reporter::CLI do
 
       let(:tty?) { true }
 
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       it_reports Unparser::Color::GREEN.format('progress: 00/02 alive: 0 runtime: 4.00s killtime: 0.00s mutations/s: 0.00') + "\n"
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
     end
 
     context 'with last mutation present' do


### PR DESCRIPTION
- When I ran `rubocop` it spat out a large number of warnings because the configuration and inline disable comments were missing the proper namespace or did not have a namespace at all. This resolves those warnings.
