### PR TITLE
Fix static csend mutation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 * Add block-pass mutations (`foo(&method(:bar))` -> `foo(&public_method(:bar))`) [#1047](https://github.com/mbj/mutant/pull/1047)
 * Add new mutation of `Array(foo)` -> `[foo]` [#1043](https://github.com/mbj/mutant/pull/1043)
-* Add new mutation to mutate dynamic sends to static sends ({`foo.__send__(:bar)`, `foo.send(:bar)`, `foo.public_send(:bar)`} -> `foo.bar`) [#1040](https://github.com/mbj/mutant/pull/1040)
+* Add new mutation to mutate dynamic sends to static sends ({`foo.__send__(:bar)`, `foo.send(:bar)`, `foo.public_send(:bar)`} -> `foo.bar`) [#1040](https://github.com/mbj/mutant/pull/1040) and [#1049](https://github.com/mbj/mutant/pull/1049)
 
 # v0.9.11 2020-08-25
 

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -103,7 +103,7 @@ module Mutant
 
           method_name = AST::Meta::Symbol.new(dynamic_selector).name
 
-          emit(s(:send, receiver, method_name, *actual_arguments))
+          emit(s(node.type, receiver, method_name, *actual_arguments))
         end
 
         def possible_kernel_method?

--- a/meta/csend.rb
+++ b/meta/csend.rb
@@ -8,3 +8,18 @@ Mutant::Meta::Example.add :csend do
   mutation 'self&.b'
   mutation 'a'
 end
+
+Mutant::Meta::Example.add :csend do
+  source 'a&.public_send(:b)'
+
+  singleton_mutations
+  mutation ':b'
+  mutation 'a.public_send(:b)'
+  mutation 'a'
+  mutation 'a&.public_send'
+  mutation 'a&.public_send(:b__mutant__)'
+  mutation 'a&.public_send(nil)'
+  mutation 'a&.public_send(self)'
+  mutation 'self&.public_send(:b)'
+  mutation 'a&.b'
+end


### PR DESCRIPTION
- When we have an expression like `a.public_send(:b)` we convert it to the form of `a.b`. In the case of `a&.b` we had previously been emitting `a.b`, but not `a&.b`. The former is less often useful but the latter can be later promoted from `a&.b` to `a.b` if applicable since we already have a mutation to remove the conditional part of the csend.