### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ mutant
 ![Build Status](https://github.com/mbj/mutant/workflows/CI/badge.svg)
 [![Gem Version](https://img.shields.io/gem/v/mutant.svg)](https://rubygems.org/gems/mutant)
 [![Slack Status](https://mutation-testing-slack.herokuapp.com/badge.svg)](https://mutation-testing.slack.com/messages/mutant)
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fmbj%2Fmutant&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 
 ## What is Mutant?
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1645)](https://user-images.githubusercontent.com/47092464/98443404-09285e80-2146-11eb-9905-c127ca456559.png)
