### PR TITLE
Support multiple subject expressions [RSpec]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add support for specifying multiple subject expressions with the RSpec integration. [#1125](https://github.com/mbj/mutant/pull/1125)
+
 # v0.10.8 2020-11-22
 
 * Add support for process abort as coverage condition.

--- a/lib/mutant/integration/rspec.rb
+++ b/lib/mutant/integration/rspec.rb
@@ -92,17 +92,22 @@ module Mutant
         }
 
         Test.new(
-          expressions: [parse_metadata(metadata)],
+          expressions: parse_metadata(metadata),
           id:          id
         )
       end
 
       def parse_metadata(metadata)
         if metadata.key?(:mutant_expression)
-          parse_expression(metadata.fetch(:mutant_expression))
+          expression = metadata.fetch(:mutant_expression)
+
+          expressions =
+            expression.instance_of?(Array) ? expression : [expression]
+
+          expressions.map(&method(:parse_expression))
         else
           match = EXPRESSION_CANDIDATE.match(metadata.fetch(:full_description))
-          parse_expression(match.captures.first) { ALL_EXPRESSION }
+          [parse_expression(match.captures.first) { ALL_EXPRESSION }]
         end
       end
 

--- a/mutant.yml
+++ b/mutant.yml
@@ -4,4 +4,5 @@ includes:
 integration: rspec
 requires:
 - mutant
+- mutant/integration/rspec
 - mutant/meta

--- a/spec/unit/mutant/integration/rspec_spec.rb
+++ b/spec/unit/mutant/integration/rspec_spec.rb
@@ -66,13 +66,25 @@ RSpec.describe Mutant::Integration::Rspec do
     )
   end
 
+  let(:example_f) do
+    double(
+      'Example E',
+      metadata: {
+        location:          'example-f-location',
+        full_description:  'Example::F',
+        mutant_expression: %w[Foo Bar]
+      }
+    )
+  end
+
   let(:examples) do
     [
       example_a,
       example_b,
       example_c,
       example_d,
-      example_e
+      example_e,
+      example_f
     ]
   end
 
@@ -118,6 +130,10 @@ RSpec.describe Mutant::Integration::Rspec do
       Mutant::Test.new(
         id:          'rspec:3:example-e-location/Example::E',
         expressions: [parse_expression('Foo')]
+      ),
+      Mutant::Test.new(
+        id:          'rspec:4:example-f-location/Example::F',
+        expressions: [parse_expression('Foo'), parse_expression('Bar')]
       )
     ]
   end


### PR DESCRIPTION
- Allows mutant users to specify that a test covers multiple subjects using `mutant_expression`, not just one.
- Closes #1079

@mbj Is this what you had in mind in terms of implementation? I thought about concatenating the subject but then I'm not sure how you could override the default subject. I was thinking just an array of subjects would be a good starting point.

Additionally, I tried to mutate this locally but it didn't seem to pick up the subject with `--since` or a direct expression. I must be doing something wrong there--not sure if CI picked up on the changes or not.