### PR TITLE
Construct file paths relative to repository root

### DIFF
--- a/lib/mutant/repository/diff.rb
+++ b/lib/mutant/repository/diff.rb
@@ -31,15 +31,21 @@ module Mutant
 
       # rubocop:disable Metrics/MethodLength
       def touched_paths
-        pathname = world.pathname
-        work_dir = pathname.pwd
+        root_stdout =
+          world
+            .capture_stdout(%w[git rev-parse --show-toplevel])
+            .from_right
+            .lines
+            .first
+            .strip
+        root_dir = Pathname.new(root_stdout)
 
         world
           .capture_stdout(%W[git diff-index #{to}])
           .from_right
           .lines
           .map do |line|
-            path = parse_line(work_dir, line)
+            path = parse_line(root_dir, line)
             [path.path, path]
           end
           .to_h


### PR DESCRIPTION
* git diff-index output is relative to git root
* running mutant deeper from the git root breaks assumption of git root
  being equal to work dir