### PR TITLE
Change back to lazy mutation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# v0.10.16 2020-12-09
+
+* Minor performance improvements on small runs.
+
+  [#1145](https://github.com/mbj/mutant/pull/1145)
+
 # v0.10.15 2020-12-07
 
 * Add support for incremental mutation testing when the working directory

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.10.15)
+    mutant (0.10.16)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)

--- a/lib/mutant/mutation.rb
+++ b/lib/mutant/mutation.rb
@@ -9,34 +9,37 @@ module Mutant
     CODE_DELIMITER = "\0"
     CODE_RANGE     = (0..4).freeze
 
-    def initialize(subject, node)
-      super(subject, node)
-
-      @source         = Unparser.unparse(node)
-      @code           = sha1[CODE_RANGE]
-      @identification = "#{self.class::SYMBOL}:#{subject.identification}:#{code}"
-      @monkeypatch    = Unparser.unparse(subject.context.root(node))
-    end
-
     # Mutation identification code
     #
     # @return [String]
-    attr_reader :code
+    def code
+      sha1[CODE_RANGE]
+    end
+    memoize :code
 
     # Normalized mutation source
     #
     # @return [String]
-    attr_reader :source
+    def source
+      Unparser.unparse(node)
+    end
+    memoize :source
 
     # Identification string
     #
     # @return [String]
-    attr_reader :identification
+    def identification
+      "#{self.class::SYMBOL}:#{subject.identification}:#{code}"
+    end
+    memoize :identification
 
     # The monkeypatch to insert the mutation
     #
     # @return [String]
-    attr_reader :monkeypatch
+    def monkeypatch
+      Unparser.unparse(subject.context.root(node))
+    end
+    memoize :monkeypatch
 
     # Normalized original source
     #

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.10.15'
+  VERSION = '0.10.16'
 end # Mutant


### PR DESCRIPTION
* It turns out that the original reason for the change to AOT
  mutation details is not valid anymore after the MRI bug that causes
  the VM to get stuck was reproduced outside memoizable sharing.