### PR TITLE
Fix stuck isolation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,10 @@
-# v0.10.16 2020-12-09
+# v0.10.17 2020-12-09
+
+* Fix low frequency stuck isolation reads.
+
+  [#1147](https://github.com/mbj/mutant/pull/1147)
+
+# v0.10.16 2020-12-08
 
 * Minor performance improvements on small runs.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.10.16)
+    mutant (0.10.17)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.10.16'
+  VERSION = '0.10.17'
 end # Mutant


### PR DESCRIPTION
This was both an MRI and a mutant problem, and its likely that the
underlying MRI problem can still manifest itself. Its now simpy just
significantly more unlikely.

A bit of context:

* Mutant is and was waiting for an FD to become readable via IO.select.
* Mutant did NOT "finish" reading the FD per IO.select return, instead
  it would only read upto 4096 bytes, even if the FD could provide more
  input. Mutant would loop around to call another IO.select on the FD.
* MRI does internally maintain a buffer before calling `read()` on the
  underlying file descriptor. Mutant often would per IO.select only hit
  that buffer, not the underlying FD.
* MRI can "forget" the Ruby side IO#read_nonblocking should not block,
  so when the buffer is exhausted it may call `read()` in blocking mode.
* Mutant triggered this (potentially buggy MRI mechanism) very often.