### PR TITLE
Add defined? -> instance_variable_defined? mutation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,13 @@
 
 * [#1155](https://github.com/mbj/mutant/pull/1155)
 
-  Add `defined?(@a)` -> `instance_variable_defined?(:@a)` mutation. 
+  * Add `defined?(@a)` -> `instance_variable_defined?(:@a)` mutation.
+  * Remove invalid mutations from `defined?` -> `true`.
+  * Remove mutations of `defined?()` arguments, the `defined?` method
+    is not fully evaluating the argument but instead partially evaluates the
+    AST, or inspects the AST.
+    Delegating to the value semantics based "generic" mutation engine does create
+    too many hard to cover mutations.
 
 # v0.10.18 2020-12-13
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -32,8 +32,8 @@
     This is useful when reacting to noop errors.
 
 * [#1154](https://github.com/mbj/mutant/pull/1154)
- 
-  * Add subcommand `environment subject list`. It allows to list 
+
+  * Add subcommand `environment subject list`. It allows to list
     all matched subjects.
 
 # v0.10.17 2020-12-09

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* [#1155](https://github.com/mbj/mutant/pull/1155)
+
+  Add `defined?(@a)` -> `instance_variable_defined?(:@a)` mutation. 
+
 # v0.10.18 2020-12-13
 
 * [#1151](https://github.com/mbj/mutant/pull/1151)

--- a/lib/mutant/mutator/node/defined.rb
+++ b/lib/mutant/mutator/node/defined.rb
@@ -13,10 +13,7 @@ module Mutant
       private
 
         def dispatch
-          emit_singletons
-          emit(N_TRUE)
-
-          emit_expression_mutations { |node| !n_self?(node) }
+          emit(N_NIL)
           emit_instance_variable_mutation
         end
 

--- a/lib/mutant/mutator/node/defined.rb
+++ b/lib/mutant/mutator/node/defined.rb
@@ -17,6 +17,18 @@ module Mutant
           emit(N_TRUE)
 
           emit_expression_mutations { |node| !n_self?(node) }
+          emit_instance_variable_mutation
+        end
+
+        def emit_instance_variable_mutation
+          return unless n_ivar?(expression)
+
+          instance_variable_name = Mutant::Util.one(expression.children)
+
+          emit(
+            s(:send, nil, :instance_variable_defined?,
+              s(:sym, instance_variable_name))
+          )
         end
 
       end # Defined

--- a/meta/defined.rb
+++ b/meta/defined.rb
@@ -3,17 +3,12 @@
 Mutant::Meta::Example.add :defined? do
   source 'defined?(foo)'
 
-  singleton_mutations
-  mutation 'defined?(nil)'
-  mutation 'true'
+  mutation 'nil'
 end
 
 Mutant::Meta::Example.add :defined? do
   source 'defined?(@foo)'
 
-  singleton_mutations
-  mutation 'defined?(nil)'
-  mutation 'defined?(foo)'
-  mutation 'true'
   mutation 'instance_variable_defined?(:@foo)'
+  mutation 'nil'
 end

--- a/meta/defined.rb
+++ b/meta/defined.rb
@@ -7,3 +7,13 @@ Mutant::Meta::Example.add :defined? do
   mutation 'defined?(nil)'
   mutation 'true'
 end
+
+Mutant::Meta::Example.add :defined? do
+  source 'defined?(@foo)'
+
+  singleton_mutations
+  mutation 'defined?(nil)'
+  mutation 'defined?(foo)'
+  mutation 'true'
+  mutation 'instance_variable_defined?(:@foo)'
+end


### PR DESCRIPTION
- Mutates expressions where `defined?` is being used to check specifically for an instance variable such as `defined?(@a)` to the more narrow `instance_variable_defined?(:@a)` instead.
- Closes #1138.