### PR TITLE
Remove unused `MAP` constant

### DIFF
--- a/lib/mutant/mutator/node/procarg_zero.rb
+++ b/lib/mutant/mutator/node/procarg_zero.rb
@@ -4,12 +4,6 @@ module Mutant
   class Mutator
     class Node
       class ProcargZero < self
-        MAP = {
-          ::Parser::AST::Node => :emit_argument_node_mutations,
-          Symbol              => :emit_argument_symbol_mutations
-        }.freeze
-
-        private_constant(*constants(false))
 
         handle :procarg0
 


### PR DESCRIPTION
- Removes an unused constant from Mutant::Mutator::Node::ProcargZero. This has not been used since #989.