### PR TITLE
Change to strict integration version bounds

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,11 @@
-# Unreleased
+# v0.10.19 2020-12-14
+
+* [#1158](https://github.com/mbj/mutant/pull/1158)
+
+  * Change to strict integration version bounds.
+  * Mutant is evolving the integration interface, and will keep doing so.
+  * Before this change integrations would declare they can work with many
+    future mutant releases, but this is actually not the case.
 
 * [#1155](https://github.com/mbj/mutant/pull/1155)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.10.18)
+    mutant (0.10.19)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.10.18'
+  VERSION = '0.10.19'
 end # Mutant

--- a/mutant-minitest.gemspec
+++ b/mutant-minitest.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('lib/mutant/version', __dir__)
+require_relative './lib/mutant/version'
 
 Gem::Specification.new do |gem|
   gem.name        = 'mutant-minitest'
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.5'
 
   gem.add_runtime_dependency('minitest', '~> 5.11')
-  gem.add_runtime_dependency('mutant',   "~> #{gem.version}")
+  gem.add_runtime_dependency('mutant',   "= #{gem.version}")
 end

--- a/mutant-rspec.gemspec
+++ b/mutant-rspec.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('lib/mutant/version', __dir__)
+require_relative 'lib/mutant/version'
 
 Gem::Specification.new do |gem|
   gem.name        = 'mutant-rspec'
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
 
-  gem.add_runtime_dependency('mutant', "~> #{gem.version}")
+  gem.add_runtime_dependency('mutant', "= #{gem.version}")
   gem.add_runtime_dependency('rspec-core', '>= 3.8.0', '< 4.0.0')
 end


### PR DESCRIPTION
* Mutant is evolving the integration interface, and will keep doing so.
* Before this change integrations would declare they can work with many
  future mutant releases, but this is actually not the case.