### PR TITLE
Change expression details to avoid memoization

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+# v0.10.20 2020-12-14
+
+  [#1159](https://github.com/mbj/mutant/pull/1159)
+  [#1160](https://github.com/mbj/mutant/pull/1160)
+
+  * Substantially improve performance on coverage attempts that involve many selected tests.
+  * Reduce (but not eliminate) performance degeneration on larger subject sets.
+  * This release for many average cases should get 2x the performance.
+
 # v0.10.19 2020-12-14
 
 * [#1158](https://github.com/mbj/mutant/pull/1158)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.10.19)
+    mutant (0.10.20)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)

--- a/lib/mutant/expression.rb
+++ b/lib/mutant/expression.rb
@@ -4,13 +4,17 @@ module Mutant
 
   # Abstract base class for match expression
   class Expression
-    include AbstractType, Adamantium::Flat
+    include AbstractType
 
     fragment             = /[A-Za-z][A-Za-z\d_]*/.freeze
     SCOPE_NAME_PATTERN   = /(?<scope_name>#{fragment}(?:#{SCOPE_OPERATOR}#{fragment})*)/.freeze
     SCOPE_SYMBOL_PATTERN = '(?<scope_symbol>[.#])'
 
     private_constant(*constants(false))
+
+    def self.new(*)
+      super.freeze
+    end
 
     # Syntax of expression
     #

--- a/lib/mutant/expression/method.rb
+++ b/lib/mutant/expression/method.rb
@@ -26,13 +26,15 @@ module Mutant
 
       REGEXP = /\A#{SCOPE_NAME_PATTERN}#{SCOPE_SYMBOL_PATTERN}#{METHOD_NAME_PATTERN}\z/.freeze
 
+      def initialize(*)
+        super
+        @syntax = [scope_name, scope_symbol, method_name].join.freeze
+      end
+
       # Syntax of expression
       #
       # @return [String]
-      def syntax
-        [scope_name, scope_symbol, method_name].join
-      end
-      memoize :syntax
+      attr_reader :syntax
 
       # Matcher for expression
       #

--- a/lib/mutant/expression/methods.rb
+++ b/lib/mutant/expression/methods.rb
@@ -20,13 +20,15 @@ module Mutant
 
       REGEXP = /\A#{SCOPE_NAME_PATTERN}#{SCOPE_SYMBOL_PATTERN}\z/.freeze
 
+      def initialize(*)
+        super
+        @syntax = [scope_name, scope_symbol].join.freeze
+      end
+
       # Syntax of expression
       #
       # @return [String]
-      def syntax
-        [scope_name, scope_symbol].join
-      end
-      memoize :syntax
+      attr_reader :syntax
 
       # Matcher on expression
       #

--- a/lib/mutant/expression/namespace.rb
+++ b/lib/mutant/expression/namespace.rb
@@ -16,6 +16,9 @@ module Mutant
         # @return [undefined]
         def initialize(*)
           super
+
+          @syntax = "#{scope_name}*"
+
           @recursion_pattern = Regexp.union(
             /\A#{scope_name}\z/,
             /\A#{scope_name}::/,
@@ -26,10 +29,7 @@ module Mutant
         # Syntax for expression
         #
         # @return [String]
-        def syntax
-          "#{scope_name}*"
-        end
-        memoize :syntax
+        attr_reader :syntax
 
         # Matcher for expression
         #
@@ -52,7 +52,6 @@ module Mutant
             0
           end
         end
-
       end # Recursive
 
       # Exact namespace expression
@@ -88,7 +87,6 @@ module Mutant
           Object.const_get(scope_name)
         rescue NameError # rubocop:disable Lint/SuppressedException
         end
-
       end # Exact
     end # Namespace
   end # Expression

--- a/lib/mutant/result.rb
+++ b/lib/mutant/result.rb
@@ -121,7 +121,7 @@ module Mutant
 
     # Test result
     class Test
-      include Result, Anima.new(:passed, :runtime)
+      include Anima.new(:passed, :runtime)
 
       class VoidValue < self
         include Singleton

--- a/lib/mutant/test.rb
+++ b/lib/mutant/test.rb
@@ -3,7 +3,7 @@
 module Mutant
   # Abstract base class for test that might kill a mutation
   class Test
-    include Adamantium::Flat, Anima.new(
+    include Anima.new(
       :expressions,
       :id
     )

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.10.19'
+  VERSION = '0.10.20'
 end # Mutant

--- a/spec/unit/mutant/expression/method_spec.rb
+++ b/spec/unit/mutant/expression/method_spec.rb
@@ -51,12 +51,16 @@ RSpec.describe Mutant::Expression::Method do
       let(:input) { instance_method }
 
       it { should eql(instance_method) }
+
+      its(:frozen?) { should be(true) }
     end
 
     context 'on singleton method' do
       let(:input) { singleton_method }
 
       it { should eql(singleton_method) }
+
+      its(:frozen?) { should be(true) }
     end
   end
 

--- a/spec/unit/mutant/expression/methods_spec.rb
+++ b/spec/unit/mutant/expression/methods_spec.rb
@@ -34,12 +34,16 @@ RSpec.describe Mutant::Expression::Methods do
       let(:attributes) { { scope_name: 'TestApp::Literal', scope_symbol: '#' } }
 
       it { should eql('TestApp::Literal#') }
+
+      its(:frozen?) { should be(true) }
     end
 
     context 'with a singleton method' do
       let(:attributes) { { scope_name: 'TestApp::Literal', scope_symbol: '.' } }
 
       it { should eql('TestApp::Literal.') }
+
+      its(:frozen?) { should be(true) }
     end
   end
 

--- a/spec/unit/mutant/expression/namespace/exact_spec.rb
+++ b/spec/unit/mutant/expression/namespace/exact_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Mutant::Expression::Namespace::Exact do
     end
   end
 
+  describe '#syntax' do
+    subject { object.syntax }
+
+    it { should eql(input) }
+  end
+
   describe '#match_length' do
     subject { object.match_length(other) }
 

--- a/spec/unit/mutant/expression/namespace/recursive_spec.rb
+++ b/spec/unit/mutant/expression/namespace/recursive_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Mutant::Expression::Namespace::Recursive do
     subject { object.syntax }
 
     it { should eql(input) }
+
+    its(:frozen?) { should be(true) }
   end
 
   describe '#match_length' do

--- a/spec/unit/mutant/expression_spec.rb
+++ b/spec/unit/mutant/expression_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe Mutant::Expression do
     end
   end
 
+  describe '#frozen?' do
+    subject { parse_expression('Foo').frozen? }
+
+    it { should be(true) }
+  end
+
   describe '.try_parse' do
     let(:object) do
       Class.new(described_class) do

--- a/test_app/Gemfile.minitest.lock
+++ b/test_app/Gemfile.minitest.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    mutant (0.10.19)
+    mutant (0.10.20)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)
@@ -16,9 +16,9 @@ PATH
       procto (~> 0.0.2)
       unparser (~> 0.5.4)
       variable (~> 0.0.1)
-    mutant-minitest (0.10.19)
+    mutant-minitest (0.10.20)
       minitest (~> 5.11)
-      mutant (= 0.10.19)
+      mutant (= 0.10.20)
 
 GEM
   remote: https://rubygems.org/

--- a/test_app/Gemfile.rspec3.8.lock
+++ b/test_app/Gemfile.rspec3.8.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    mutant (0.10.19)
+    mutant (0.10.20)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)
@@ -16,8 +16,8 @@ PATH
       procto (~> 0.0.2)
       unparser (~> 0.5.4)
       variable (~> 0.0.1)
-    mutant-rspec (0.10.19)
-      mutant (= 0.10.19)
+    mutant-rspec (0.10.20)
+      mutant (= 0.10.20)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM


### PR DESCRIPTION
* This avoids marshalling/unmarshaling memoization caches
* The attribute is quick to precompute and not having the machinery of
  memoization improves latency.