### PR TITLE
Change to narrow test integration interface

### DIFF
--- a/lib/mutant/integration/minitest.rb
+++ b/lib/mutant/integration/minitest.rb
@@ -99,7 +99,6 @@ module Mutant
 
         Result::Test.new(
           passed:  reporter.passed?,
-          tests:   tests,
           runtime: timer.now - start
         )
       end

--- a/lib/mutant/integration/null.rb
+++ b/lib/mutant/integration/null.rb
@@ -16,11 +16,10 @@ module Mutant
       # @param [Enumerable<Mutant::Test>] tests
       #
       # @return [Result::Test]
-      def call(tests)
+      def call(_tests)
         Result::Test.new(
           passed:  true,
-          runtime: 0.0,
-          tests:   tests
+          runtime: 0.0
         )
       end
 

--- a/lib/mutant/integration/rspec.rb
+++ b/lib/mutant/integration/rspec.rb
@@ -54,14 +54,13 @@ module Mutant
       #
       # @return [Result::Test]
       def call(tests)
-        examples = tests.map(&all_tests_index.method(:fetch))
-        filter_examples(&examples.method(:include?))
+        examples = tests.map(&all_tests_index)
+        filter_examples(&examples.public_method(:include?))
         start = timer.now
         passed = @runner.run_specs(@world.ordered_example_groups).equal?(EXIT_SUCCESS)
         Result::Test.new(
           passed:  passed,
-          runtime: timer.now - start,
-          tests:   tests
+          runtime: timer.now - start
         )
       end
 

--- a/lib/mutant/result.rb
+++ b/lib/mutant/result.rb
@@ -121,11 +121,7 @@ module Mutant
 
     # Test result
     class Test
-      include Result, Anima.new(
-        :passed,
-        :runtime,
-        :tests
-      )
+      include Result, Anima.new(:passed, :runtime)
 
       class VoidValue < self
         include Singleton
@@ -137,7 +133,6 @@ module Mutant
           super(
             passed:  false,
             runtime: 0.0,
-            tests:   []
           )
         end
       end # VoidValue

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -196,7 +196,6 @@ module SharedContext
 
     let(:mutation_a_test_result) do
       Mutant::Result::Test.new(
-        tests:   [test_a],
         passed:  false,
         runtime: 1.0
       )
@@ -204,7 +203,6 @@ module SharedContext
 
     let(:mutation_b_test_result) do
       Mutant::Result::Test.new(
-        tests:   [test_a],
         passed:  false,
         runtime: 1.0
       )

--- a/spec/unit/mutant/integration/rspec_spec.rb
+++ b/spec/unit/mutant/integration/rspec_spec.rb
@@ -189,8 +189,7 @@ RSpec.describe Mutant::Integration::Rspec do
         expect(subject).to eql(
           Mutant::Result::Test.new(
             passed:  false,
-            runtime: 0.0,
-            tests:   tests
+            runtime: 0.0
           )
         )
       end
@@ -203,8 +202,7 @@ RSpec.describe Mutant::Integration::Rspec do
         expect(subject).to eql(
           Mutant::Result::Test.new(
             passed:  true,
-            runtime: 0.0,
-            tests:   tests
+            runtime: 0.0
           )
         )
       end

--- a/spec/unit/mutant/integration_spec.rb
+++ b/spec/unit/mutant/integration_spec.rb
@@ -164,8 +164,7 @@ RSpec.describe Mutant::Integration::Null do
       should eql(
         Mutant::Result::Test.new(
           passed:  true,
-          runtime: 0.0,
-          tests:   tests
+          runtime: 0.0
         )
       )
     end

--- a/spec/unit/mutant/result/test_spec.rb
+++ b/spec/unit/mutant/result/test_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Mutant::Result::Test::VoidValue do
     it 'returns expected attributes' do
       expect(described_class.instance.to_h).to eql(
         passed:  false,
-        runtime: 0.0,
-        tests:   []
+        runtime: 0.0
       )
     end
   end

--- a/test_app/Gemfile.minitest.lock
+++ b/test_app/Gemfile.minitest.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    mutant (0.10.17)
+    mutant (0.10.19)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)
@@ -16,9 +16,9 @@ PATH
       procto (~> 0.0.2)
       unparser (~> 0.5.4)
       variable (~> 0.0.1)
-    mutant-minitest (0.10.17)
+    mutant-minitest (0.10.19)
       minitest (~> 5.11)
-      mutant (~> 0.10.17)
+      mutant (= 0.10.19)
 
 GEM
   remote: https://rubygems.org/

--- a/test_app/Gemfile.rspec3.8.lock
+++ b/test_app/Gemfile.rspec3.8.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    mutant (0.10.17)
+    mutant (0.10.19)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.1)
@@ -16,8 +16,8 @@ PATH
       procto (~> 0.0.2)
       unparser (~> 0.5.4)
       variable (~> 0.0.1)
-    mutant-rspec (0.10.17)
-      mutant (~> 0.10.17)
+    mutant-rspec (0.10.19)
+      mutant (= 0.10.19)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM


### PR DESCRIPTION
* This reduces the payload that has to be communicate from the killforks
  to the main process.
* Nice increase in synthetic benchmarks.