### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: bundler
-  directory: /
-  schedule:
-    interval: daily


### PR DESCRIPTION
* While its generally useful, it creates too much noise for watchers of
  the repository.
* Mutant used to have ~45 followers 4 weeks ago, now its down to 39.
  have to attribute this to the noise generated by dependabot that (sadly)
  updates each dependency in an isolated PR, which creates lots of
  noise.