### PR TITLE
Fix `rspec` error matcher warning

### DIFF
--- a/spec/unit/mutant/ast/find_metaclass_containing_spec.rb
+++ b/spec/unit/mutant/ast/find_metaclass_containing_spec.rb
@@ -13,7 +13,12 @@ RSpec.describe Mutant::AST::FindMetaclassContaining do
     context 'when called without ast' do
       let(:ast) { nil }
 
-      it { expect { subject }.to raise_error }
+      it 'raises a NoMethodError' do
+        expect { subject }.to raise_error(
+          NoMethodError,
+          "undefined method `type' for nil:NilClass"
+        )
+      end
     end
 
     context 'when called without node' do


### PR DESCRIPTION
- Prior to this commit every run of `rspec spec/unit` would output the following:
> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<NoMethodError: undefined method `type' for nil:NilClass>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/gollahon/oss/mutant/spec/unit/mutant/ast/find_metaclass_containing_spec.rb:16:in `block (4 levels) in <top (required)>'

- This change narrows the assertion somewhat and makes the conerns raised by the warning much less likely to be an issue and reduces the noise outputted when running the specs.