### PR TITLE
Add `a === b` -> `a.is_a?(b)` mutation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+
+* [#1188](https://github.com/mbj/mutant/pull/1188)
+
+  Add `a === b` -> `a.is_a?(b)` mutation
+
 * [#1189](https://github.com/mbj/mutant/pull/1189)
 
   * Add mutation from `=~` -> `#match?`

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -17,6 +17,7 @@ module Mutant
           :< =>          %i[== eql? equal?],
           :<= =>         %i[< == eql? equal?],
           :== =>         %i[eql? equal?],
+          :=== =>        %i[is_a?],
           :=~ =>         %i[match?],
           :> =>          %i[== eql? equal?],
           :>= =>         %i[> == eql? equal?],

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -562,7 +562,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo(n..-2)'
 end
 
-(Mutant::AST::Types::BINARY_METHOD_OPERATORS - %i[=~ <= >= < > == != eql?]).each do |operator|
+(Mutant::AST::Types::BINARY_METHOD_OPERATORS - %i[=~ <= >= < > == === != eql?]).each do |operator|
   Mutant::Meta::Example.add :send do
     source "true #{operator} false"
 
@@ -728,4 +728,18 @@ Mutant::Meta::Example.add :send do
 
   mutation 'foo'
   mutation 'foo(a__mutant__: nil)'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'a === b'
+
+  singleton_mutations
+
+  mutation 'a'
+  mutation 'b'
+  mutation 'nil === b'
+  mutation 'self === b'
+  mutation 'a === nil'
+  mutation 'a === self'
+  mutation 'a.is_a?(b)'
 end


### PR DESCRIPTION
- Closes #689
	* NOTE: I have gone with `is_a?` over `kind_of?` because [this is more commonly used](https://github.com/rubocop-hq/ruby-style-guide#is-a-vs-kind-of)