### PR TITLE
Remove duplicate meta examples

### DIFF
--- a/meta/block.rb
+++ b/meta/block.rb
@@ -80,16 +80,6 @@ Mutant::Meta::Example.add :block do
 end
 
 Mutant::Meta::Example.add :block do
-  source 'foo { |a| }'
-
-  singleton_mutations
-  mutation 'foo { || }'
-  mutation 'foo { |a| raise }'
-  mutation 'foo { |_a| }'
-  mutation 'foo'
-end
-
-Mutant::Meta::Example.add :block do
   source 'foo { bar(nil) }'
 
   singleton_mutations

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -220,21 +220,6 @@ Mutant::Meta::Example.add :send do
 end
 
 Mutant::Meta::Example.add :send do
-  source 'foo.is_a?(bar)'
-
-  singleton_mutations
-  mutation 'foo'
-  mutation 'bar'
-  mutation 'foo.is_a?'
-  mutation 'foo.is_a?(nil)'
-  mutation 'foo.is_a?(self)'
-  mutation 'self.is_a?(bar)'
-  mutation 'foo.instance_of?(bar)'
-  mutation 'false'
-  mutation 'true'
-end
-
-Mutant::Meta::Example.add :send do
   source 'foo.kind_of?(bar)'
 
   singleton_mutations

--- a/spec/unit/mutant/meta/example_spec.rb
+++ b/spec/unit/mutant/meta/example_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe Mutant::Meta::Example do
     end
   end
 
+  it 'does not define any repeated examples' do
+    source_counts = described_class::ALL.each_with_object(Hash.new(0)) do |example, counts|
+      counts["#{example.location.path}:#{example.original_source}"] += 1
+    end
+
+    expect(source_counts.select { |_source, count| count > 1 }.keys).to eql([])
+  end
+
   describe '#original_source_generated' do
     subject { object.original_source_generated }
 


### PR DESCRIPTION
I found a couple of meta examples that were duplicated so I am removing them. I have additionally added a test to prevent this from recurring.