### PR TITLE
Add predicate method mutations 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+* [#1192](https://github.com/mbj/mutant/pull/1192)
+
+  * Add mutations from predicate-like methods (methods ending in ?) to `true`/`false`
+      * `a.b?` -> `false`
+      * `a.b?` -> `true`
+
 * [#1186](https://github.com/mbj/mutant/pull/1186)
 
   Add additional `*` -> `+` regexp quantifier mutations:

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -84,6 +84,7 @@ module Mutant
         end
 
         def emit_selector_specific_mutations
+          emit_predicate_mutations
           emit_array_mutation
           emit_static_send
           emit_const_get_mutation
@@ -91,6 +92,13 @@ module Mutant
           emit_dig_mutation
           emit_double_negation_mutation
           emit_lambda_mutation
+        end
+
+        def emit_predicate_mutations
+          return unless selector.match?(/\?\z/) && !selector.equal?(:defined?)
+
+          emit(s(:true))
+          emit(s(:false))
         end
 
         def emit_array_mutation

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -104,6 +104,8 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'any?'
+  mutation 'false'
+  mutation 'true'
 end
 
 Mutant::Meta::Example.add :send do
@@ -111,6 +113,8 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'all?'
+  mutation 'false'
+  mutation 'true'
 end
 
 Mutant::Meta::Example.add :send do
@@ -211,6 +215,8 @@ Mutant::Meta::Example.add :send do
   mutation 'foo.is_a?(self)'
   mutation 'self.is_a?(bar)'
   mutation 'foo.instance_of?(bar)'
+  mutation 'false'
+  mutation 'true'
 end
 
 Mutant::Meta::Example.add :send do
@@ -224,6 +230,8 @@ Mutant::Meta::Example.add :send do
   mutation 'foo.is_a?(self)'
   mutation 'self.is_a?(bar)'
   mutation 'foo.instance_of?(bar)'
+  mutation 'false'
+  mutation 'true'
 end
 
 Mutant::Meta::Example.add :send do
@@ -237,6 +245,8 @@ Mutant::Meta::Example.add :send do
   mutation 'foo.kind_of?(self)'
   mutation 'self.kind_of?(bar)'
   mutation 'foo.instance_of?(bar)'
+  mutation 'false'
+  mutation 'true'
 end
 
 Mutant::Meta::Example.add :send do


### PR DESCRIPTION
- Adds mutations from predicate-like methods (methods ending in ?) to `true`/`false`
  * `a.b?` -> `false`
  * `a.b?` -> `true`
- Closes #263