### PR TITLE
Remove outdated meta examples

### DIFF
--- a/meta/regexp.rb
+++ b/meta/regexp.rb
@@ -75,26 +75,6 @@ Mutant::Meta::Example.add :regexp do
   mutation '/(?(1)(foo)(?:bar))/'
 end
 
-# MRI accepts this regex but `regexp_parser` does not.
-# See: https://github.com/ammar/regexp_parser/issues/75
-Mutant::Meta::Example.add :regexp do
-  source '/\xA/'
-
-  singleton_mutations
-  mutation '//'
-  mutation '/nomatch\A/'
-end
-
-# MRI accepts this regex but `regexp_parser` does not.
-# See: https://github.com/ammar/regexp_parser/issues/76
-Mutant::Meta::Example.add :regexp do
-  source '/(?<æ>.)/'
-
-  singleton_mutations
-  mutation '//'
-  mutation '/nomatch\A/'
-end
-
 Pathname
   .glob(Pathname.new(__dir__).join('regexp', '*.rb'))
   .sort


### PR DESCRIPTION
- These were added to account for special cases listed in the neighboring comments. Since these upstream issues have been fixed and we are pinned to a version past these, they are no longer necessary to test explicitly.