### PR TITLE
Fix flakey specs

### DIFF
--- a/spec/unit/mutant/subject/method/instance_spec.rb
+++ b/spec/unit/mutant/subject/method/instance_spec.rb
@@ -81,10 +81,6 @@ RSpec.describe Mutant::Subject::Method::Instance::Memoized do
   let(:context)  { Mutant::Context.new(scope, double('Source Path')) }
   let(:node)     { Unparser.parse('def foo; end')                    }
 
-  before do
-    allow(Object).to receive_messages(const_get: scope)
-  end
-
   shared_context 'memoizable scope setup' do
     let(:scope) do
       Class.new do


### PR DESCRIPTION
- This seems to be caused by stubbing `Object.const_get`. `IceNine` relies on `.const_get` to build an internal cache that it uses to perform deep freezing. This was introduced in b7c1fc788 but removing it still allows the tests to pass and gives full mutation coverage.