### PR TITLE
Add `#start_with?` and `#end_with?` mutations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+* [#1201](https://github.com/mbj/mutant/pull/1201)
+
+  * Add `/\Astatic/` -> `#start_with?` mutations:
+    * `a.match(/\Atext/)` -> `b.start_with?('text')`
+    * `a.match?(/\Atext/)` -> `b.start_with?('text')`
+    * `a =~ /\Atext/` -> `b.start_with?('text')`
+
 * [#1200](https://github.com/mbj/mutant/pull/1200)
   * Add unused group name mutation:  `/(?<foo>bar)/` -> `/(?<_foo>bar)/`.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@
     * `a.match(/\Atext/)` -> `b.start_with?('text')`
     * `a.match?(/\Atext/)` -> `b.start_with?('text')`
     * `a =~ /\Atext/` -> `b.start_with?('text')`
+  * Add `/static\z/` -> `#end_with?` mutations:
+    * `a.match(/text\z/)` -> `b.end_with?('text')`
+    * `a.match?(/text\z/)` -> `b.end_with?('text')`
+    * `a =~ /text\z/` -> `b.end_with?('text')`
 
 * [#1200](https://github.com/mbj/mutant/pull/1200)
   * Add unused group name mutation:  `/(?<foo>bar)/` -> `/(?<_foo>bar)/`.

--- a/lib/mutant/ast/regexp.rb
+++ b/lib/mutant/ast/regexp.rb
@@ -32,6 +32,23 @@ module Mutant
       def self.to_expression(node)
         Transformer.lookup(node.type).to_expression(node)
       end
+
+      # Convert's a `parser` `regexp` node into more fine-grained AST nodes.
+      #
+      # @param node [Parser::AST::Node]
+      #
+      # @return [Parser::AST::Node]
+      def self.expand_regexp_ast(node)
+        *body, _opts = node.children
+
+        # NOTE: We only mutate parts of regexp body if the body is composed of
+        # only strings. Regular expressions with interpolation are skipped
+        return unless body.all? { |child| child.type.equal?(:str) }
+
+        body_expression = parse(body.map(&:children).join)
+
+        to_ast(body_expression)
+      end
     end # Regexp
   end # AST
 end # Mutant

--- a/lib/mutant/mutator/node/literal/regex.rb
+++ b/lib/mutant/mutator/node/literal/regex.rb
@@ -28,29 +28,15 @@ module Mutant
             emit_type(s(:str, NULL_REGEXP_SOURCE), options)
           end
 
-          # NOTE: will only mutate parts of regexp body if the
-          # body is composed of only strings. Regular expressions
-          # with interpolation are skipped
           def mutate_body
-            return unless body.all?(&method(:n_str?))
+            # NOTE: will only mutate parts of regexp body if the body is composed of only strings.
+            # Regular expressions with interpolation are skipped.
+            return unless (body_ast = AST::Regexp.expand_regexp_ast(input))
 
             Mutator.mutate(body_ast).each do |mutation|
               source = AST::Regexp.to_expression(mutation).to_s
               emit_type(s(:str, source), options)
             end
-          end
-
-          def body_ast
-            AST::Regexp.to_ast(body_expression)
-          end
-
-          def body_expression
-            AST::Regexp.parse(body.map(&:children).join)
-          end
-          memoize :body_expression
-
-          def body
-            children.slice(0...-1)
           end
 
         end # Regex

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -738,3 +738,76 @@ Mutant::Meta::Example.add :send do
   mutation 'a === self'
   mutation 'a.is_a?(b)'
 end
+
+Mutant::Meta::Example.add :send do
+  source 'a.match?(/\Afoo/)'
+
+  singleton_mutations
+
+  mutation 'a'
+  mutation 'a.match?'
+  mutation '/\Afoo/'
+  mutation 'self.match?(/\Afoo/)'
+  mutation 'a.match?(//)'
+  mutation 'a.match?(/nomatch\A/)'
+  mutation "a.start_with?('foo')"
+  mutation 'false'
+  mutation 'true'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'match(/\A\d/)'
+
+  singleton_mutations
+
+  mutation 'match'
+  mutation '/\A\d/'
+  mutation 'match?(/\A\d/)'
+  mutation 'match(/\A\D/)'
+  mutation 'match(//)'
+  mutation 'match(/nomatch\A/)'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'a =~ /\Afoo/'
+
+  singleton_mutations
+
+  mutation 'a'
+  mutation 'nil =~ /\Afoo/'
+  mutation 'self =~ /\Afoo/'
+  mutation '/\Afoo/'
+  mutation 'a =~ //'
+  mutation 'a =~ /nomatch\A/'
+  mutation 'a.match?(/\Afoo/)'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'match?(/\Afoo/, 1)'
+
+  singleton_mutations
+
+  mutation 'match?(/\Afoo/)'
+  mutation 'match?(1)'
+  mutation 'match?(/\Afoo/, nil)'
+  mutation 'match?(/\Afoo/, self)'
+  mutation 'match?(/\Afoo/, -1)'
+  mutation 'match?(/\Afoo/, 0)'
+  mutation 'match?(/\Afoo/, 2)'
+  mutation 'match?'
+  mutation 'match?(//, 1)'
+  mutation 'match?(/nomatch\A/, 1)'
+  mutation 'false'
+  mutation 'true'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo(/\Abar/)'
+
+  singleton_mutations
+
+  mutation 'foo'
+  mutation '/\Abar/'
+  mutation 'foo(//)'
+  mutation 'foo(/nomatch\A/)'
+end

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -811,3 +811,18 @@ Mutant::Meta::Example.add :send do
   mutation 'foo(//)'
   mutation 'foo(/nomatch\A/)'
 end
+
+Mutant::Meta::Example.add :send do
+  source 'a.match(/foo\z/)'
+
+  singleton_mutations
+
+  mutation 'a.match?(/foo\z/)'
+  mutation 'a.match'
+  mutation 'a'
+  mutation '/foo\z/'
+  mutation 'a.match(//)'
+  mutation 'a.match(/nomatch\A/)'
+  mutation 'self.match(/foo\z/)'
+  mutation "a.end_with?('foo')"
+end

--- a/mutant.yml
+++ b/mutant.yml
@@ -12,7 +12,6 @@ matcher:
   ignore:
   - Mutant::Isolation::Fork::Parent#call
   - Mutant::Mutator::Node::Argument#skip?
-  - Mutant::Mutator::Node::Literal::Regex#body
   - Mutant::Mutator::Node::ProcargZero#dispatch
   - Mutant::Mutator::Node::When#mutate_conditions
   - Mutant::Zombifier#call

--- a/spec/unit/mutant/ast/regexp/expand_regexp_ast_spec.rb
+++ b/spec/unit/mutant/ast/regexp/expand_regexp_ast_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Mutant::AST::Regexp, '.expand_regexp_ast' do
+  it 'returns the expanded AST' do
+    parser_ast = Unparser.parse('/foo/')
+
+    expect(described_class.expand_regexp_ast(parser_ast)).to eql(
+      s(:regexp_root_expression,
+        s(:regexp_literal_literal, 'foo'))
+    )
+  end
+
+  it 'returns `nil` for complex regexps' do
+    parser_ast = Unparser.parse('/foo#{bar}/')
+
+    expect(described_class.expand_regexp_ast(parser_ast)).to be(nil)
+  end
+end


### PR DESCRIPTION
- Adds the following mutations:
  * `a.match(/\Atext/)` -> `b.start_with?('text')`
  * `a.match?(/\Atext/)` -> `b.start_with?('text')`
  * `a =~ /\Atext/` -> `b.start_with?('text')`
- NOTE: Adds a `Mutant::AST::Regexp.expand_regexp_ast` to avoid repeating AST expansion logic in the `send` mutator. At that level, the node appears as a simple `parser` `s(:regexp ...)` node so I chose to fully parse the regexp rather than try to do a string pattern.
- Also adds following mutations:
  * `a.match(/text\z/)` -> `b.end_with?('text')`
  * `a.match?(/text\z/)` -> `b.end_with?('text')`
  * `a =~ /text\z/` -> `b.end_with?('text')`
- Closes #169.