### PR TITLE
Remove `#eql?` -> `#equal?` mutation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* [#1207](https://github.com/mbj/mutant/pull/1207)
+
+  * Remove `#eql?` -> `#equal?` mutation
+
 * [#1210](https://github.com/mbj/mutant/pull/1210)
   * Remove generic mutation to `self`
 

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -25,7 +25,6 @@ module Mutant
           all?:          %i[any?],
           any?:          %i[all?],
           at:            %i[fetch key?],
-          eql?:          %i[equal?],
           fetch:         %i[key?],
           flat_map:      %i[map],
           gsub:          %i[sub],


### PR DESCRIPTION
- This mutation has become very frustrating to deal with in certain situations. Notably, due to frozen string literals everywhere matching on `#equal?` one must ensure tests use unfrozen strings using `+` or other similar hacks. I also think that `#eql?` -> `#equal?` has very limited value in most situations.
- NOTE: I have left in mutations to `equal?` as long as there are alternatives to `equal?` in the possible mutations so it is not forced over `#eql?`.