### PR TITLE
Remove generic mutation to `self`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* [#1210](https://github.com/mbj/mutant/pull/1210)
+  * Remove generic mutation to `self`
+
 # v0.10.26 2021-01-16
 
 * [#1201](https://github.com/mbj/mutant/pull/1201)

--- a/lib/mutant/meta/example/dsl.rb
+++ b/lib/mutant/meta/example/dsl.rb
@@ -79,7 +79,6 @@ module Mutant
 
         def singleton_mutations
           mutation('nil')
-          mutation('self')
         end
 
         def regexp_mutations

--- a/lib/mutant/mutator/node.rb
+++ b/lib/mutant/mutator/node.rb
@@ -67,11 +67,6 @@ module Mutant
 
       def emit_singletons
         emit_nil
-        emit_self
-      end
-
-      def emit_self
-        emit(N_SELF)
       end
 
       def emit_nil

--- a/lib/mutant/mutator/node/index.rb
+++ b/lib/mutant/mutator/node/index.rb
@@ -17,6 +17,7 @@ module Mutant
         def dispatch
           emit_singletons
           emit_receiver_mutations { |node| !n_nil?(node) }
+          emit_type(N_SELF, *children.drop(1))
           emit(receiver)
           emit_send_forms
           emit_drop_mutation

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -232,9 +232,16 @@ module Mutant
         def mutate_receiver
           return unless receiver
           emit_implicit_self
+          emit_explicit_self
           emit_receiver_mutations do |node|
             !n_nil?(node)
           end
+        end
+
+        def emit_explicit_self
+          return if UNARY_METHOD_OPERATORS.include?(selector)
+
+          emit_receiver(N_SELF) unless n_nil?(receiver)
         end
 
         def emit_implicit_self

--- a/meta/and_asgn.rb
+++ b/meta/and_asgn.rb
@@ -10,5 +10,4 @@ Mutant::Meta::Example.add :and_asgn do
   mutation 'a &&= 0'
   mutation 'a &&= -1'
   mutation 'a &&= 2'
-  mutation 'a &&= self'
 end

--- a/meta/block.rb
+++ b/meta/block.rb
@@ -9,9 +9,7 @@ Mutant::Meta::Example.add :block do
   mutation 'foo {}'
   mutation 'foo { raise }'
   mutation 'foo { a; nil }'
-  mutation 'foo { a; self }'
   mutation 'foo { nil; b }'
-  mutation 'foo { self; b }'
   mutation 'foo'
   mutation 'a; b'
 end
@@ -51,8 +49,6 @@ Mutant::Meta::Example.add :block do
   singleton_mutations
   mutation 'foo(a, nil) {}'
   mutation 'foo(nil, b) {}'
-  mutation 'foo(self, b) {}'
-  mutation 'foo(a, self) {}'
   mutation 'foo(a, b)'
   mutation 'foo(a, b) { raise }'
   mutation 'foo(a) {}'
@@ -87,7 +83,6 @@ Mutant::Meta::Example.add :block do
   mutation 'foo { bar }'
   mutation 'foo { nil }'
   mutation 'foo {}'
-  mutation 'foo { self }'
   mutation 'foo { raise }'
   mutation 'foo.bar(nil)'
   mutation 'bar(nil)'
@@ -115,10 +110,8 @@ Mutant::Meta::Example.add :block do
   singleton_mutations
   mutation 'foo'
   mutation 'foo { }'
-  mutation 'foo { self }'
   mutation 'foo { nil }'
   mutation 'foo { raise }'
-  mutation 'foo { self if true }'
   mutation 'foo { nil if true }'
   mutation 'foo { break if true }'
   mutation 'foo { next if !true }'
@@ -132,7 +125,6 @@ Mutant::Meta::Example.add :block do
   singleton_mutations
   mutation 'foo { nil }'
   mutation 'foo { raise }'
-  mutation 'foo { self }'
   mutation 'foo { break }'
   mutation 'foo { }'
   mutation 'foo'
@@ -144,10 +136,8 @@ Mutant::Meta::Example.add :block do
   singleton_mutations
   mutation 'foo'
   mutation 'foo { }'
-  mutation 'foo { self }'
   mutation 'foo { nil }'
   mutation 'foo { raise }'
-  mutation 'foo { self if true }'
   mutation 'foo { nil if true }'
   mutation 'foo { break if !true }'
   mutation 'foo { break if false }'
@@ -160,7 +150,6 @@ Mutant::Meta::Example.add :block do
   singleton_mutations
   mutation 'foo { nil }'
   mutation 'foo { raise }'
-  mutation 'foo { self }'
   mutation 'foo { }'
   mutation 'foo'
 end
@@ -175,7 +164,6 @@ Mutant::Meta::Example.add :block do
   mutation 'foo(&:bar).baz'
   mutation 'self.baz {}'
   mutation 'foo(&nil).baz {}'
-  mutation 'foo(&self).baz {}'
   mutation 'foo(&:bar__mutant__).baz {}'
 end
 
@@ -190,7 +178,6 @@ Mutant::Meta::Example.add :block do
   mutation 'self.baz { }'
   mutation 'foo(nil, &:bar).baz'
 
-  mutation 'foo(nil, &self).baz {}'
   mutation 'foo(nil, &nil).baz {}'
   mutation 'foo(nil, &:bar__mutant__).baz {}'
 end

--- a/meta/block_pass.rb
+++ b/meta/block_pass.rb
@@ -6,7 +6,6 @@ Mutant::Meta::Example.add :block_pass do
   singleton_mutations
   mutation 'foo'
   mutation 'foo(&nil)'
-  mutation 'foo(&self)'
 end
 
 Mutant::Meta::Example.add :block_pass do
@@ -15,10 +14,8 @@ Mutant::Meta::Example.add :block_pass do
   singleton_mutations
   mutation 'foo'
   mutation 'foo(&nil)'
-  mutation 'foo(&self)'
   mutation 'foo(&method)'
   mutation 'foo(&method(nil))'
-  mutation 'foo(&method(self))'
   mutation 'foo(&method(:bar__mutant__))'
   mutation 'foo(&public_method(:bar))'
   mutation 'foo(&:bar)'
@@ -30,7 +27,6 @@ Mutant::Meta::Example.add :block_pass do
   singleton_mutations
   mutation 'foo'
   mutation 'foo(&nil)'
-  mutation 'foo(&self)'
   mutation 'foo(&:to_str)'
   mutation 'foo(&:to_s__mutant__)'
 end
@@ -41,6 +37,5 @@ Mutant::Meta::Example.add :block_pass do
   singleton_mutations
   mutation 'foo'
   mutation 'foo(&nil)'
-  mutation 'foo(&self)'
   mutation 'foo(&:bar__mutant__)'
 end

--- a/meta/case.rb
+++ b/meta/case.rb
@@ -50,16 +50,6 @@ Mutant::Meta::Example.add :case do
   RUBY
 
   mutation <<-RUBY
-    case self
-    when A
-    when B, C
-      C
-    else
-      D
-    end
-  RUBY
-
-  mutation <<-RUBY
     case condition
     when A
       raise
@@ -73,16 +63,6 @@ Mutant::Meta::Example.add :case do
   mutation <<-RUBY
     case condition
     when nil
-    when B, C
-      C
-    else
-      D
-    end
-  RUBY
-
-  mutation <<-RUBY
-    case condition
-    when self
     when B, C
       C
     else
@@ -112,16 +92,6 @@ Mutant::Meta::Example.add :case do
   mutation <<-RUBY
     case condition
     when A
-    when B, C
-      self
-    else
-      D
-    end
-  RUBY
-
-  mutation <<-RUBY
-    case condition
-    when A
     when C
       C
     else
@@ -133,16 +103,6 @@ Mutant::Meta::Example.add :case do
     case condition
     when A
     when nil, C
-      C
-    else
-      D
-    end
-  RUBY
-
-  mutation <<-RUBY
-    case condition
-    when A
-    when self, C
       C
     else
       D
@@ -172,16 +132,6 @@ Mutant::Meta::Example.add :case do
   mutation <<-RUBY
     case condition
     when A
-    when B, self
-      C
-    else
-      D
-    end
-  RUBY
-
-  mutation <<-RUBY
-    case condition
-    when A
     else
       D
     end
@@ -194,16 +144,6 @@ Mutant::Meta::Example.add :case do
       C
     else
       nil
-    end
-  RUBY
-
-  mutation <<-RUBY
-    case condition
-    when A
-    when B, C
-      C
-    else
-      self
     end
   RUBY
 

--- a/meta/class.rb
+++ b/meta/class.rb
@@ -4,7 +4,6 @@ Mutant::Meta::Example.add :class do
   source 'class Foo; bar; end'
 
   mutation 'class Foo; nil; end'
-  mutation 'class Foo; self; end'
 end
 
 Mutant::Meta::Example.add :class do

--- a/meta/csend.rb
+++ b/meta/csend.rb
@@ -19,7 +19,6 @@ Mutant::Meta::Example.add :csend do
   mutation 'a&.public_send'
   mutation 'a&.public_send(:b__mutant__)'
   mutation 'a&.public_send(nil)'
-  mutation 'a&.public_send(self)'
   mutation 'self&.public_send(:b)'
   mutation 'a&.b'
 end

--- a/meta/def.rb
+++ b/meta/def.rb
@@ -12,7 +12,6 @@ Mutant::Meta::Example.add :def do
 
   mutation 'def foo; raise; end'
   mutation 'def foo; nil; rescue; end'
-  mutation 'def foo; self; rescue; end'
   mutation 'def foo; end'
   mutation 'def foo; super; end'
 
@@ -25,11 +24,8 @@ Mutant::Meta::Example.add :def do
 
   # Mutate all bodies
   mutation 'def a; nil;  rescue; bar; else; baz; end'
-  mutation 'def a; self; rescue; bar; else; baz; end'
   mutation 'def a; foo; rescue; nil;  else; baz; end'
-  mutation 'def a; foo; rescue; self; else; baz; end'
   mutation 'def a; foo; rescue; bar; else; nil; end'
-  mutation 'def a; foo; rescue; bar; else; self; end'
 
   # Promote and concat rescue resbody bodies
   mutation 'def a; foo; bar; end'
@@ -128,10 +124,8 @@ Mutant::Meta::Example.add :def do
   mutation 'def foo(_a = 0, b = 0); end'
   mutation 'def foo(a = 0, b = 1); end'
   mutation 'def foo(a = 0, b = -1); end'
-  mutation 'def foo(a = 0, b = self); end'
   mutation 'def foo(a = 0, b = nil); end'
   mutation 'def foo(a = -1, b = 0); end'
-  mutation 'def foo(a = self, b = 0); end'
   mutation 'def foo(a = nil, b = 0); end'
   mutation 'def foo(a = 1, b = 0); end'
   mutation 'def foo(a = 0); end'

--- a/meta/dstr.rb
+++ b/meta/dstr.rb
@@ -5,5 +5,4 @@ Mutant::Meta::Example.add :dstr do
 
   singleton_mutations
   mutation '"foo#{nil}baz"'
-  mutation '"foo#{self}baz"'
 end

--- a/meta/dsym.rb
+++ b/meta/dsym.rb
@@ -6,5 +6,4 @@ Mutant::Meta::Example.add :dsym do
   singleton_mutations
 
   mutation ':"foo#{nil}baz"'
-  mutation ':"foo#{self}baz"'
 end

--- a/meta/index.rb
+++ b/meta/index.rb
@@ -27,7 +27,6 @@ Mutant::Meta::Example.add :index do
   mutation 'foo[2]'
   mutation 'foo[-1]'
   mutation 'foo[nil]'
-  mutation 'foo[self]'
 end
 
 Mutant::Meta::Example.add :index do
@@ -42,9 +41,7 @@ Mutant::Meta::Example.add :index do
   mutation 'foo.key?(n..-2)'
   mutation 'self[n..-2]'
   mutation 'foo[nil]'
-  mutation 'foo[self]'
   mutation 'foo[n..nil]'
-  mutation 'foo[n..self]'
   mutation 'foo[n..-1]'
   mutation 'foo[n..2]'
   mutation 'foo[n..0]'
@@ -52,7 +49,6 @@ Mutant::Meta::Example.add :index do
   mutation 'foo[n..-3]'
   mutation 'foo[n...-2]'
   mutation 'foo[nil..-2]'
-  mutation 'foo[self..-2]'
 end
 
 Mutant::Meta::Example.add :index do
@@ -67,15 +63,12 @@ Mutant::Meta::Example.add :index do
   mutation 'foo.key?(n...-1)'
   mutation 'self[n...-1]'
   mutation 'foo[nil]'
-  mutation 'foo[self]'
   mutation 'foo[n...nil]'
-  mutation 'foo[n...self]'
   mutation 'foo[n..-1]'
   mutation 'foo[n...0]'
   mutation 'foo[n...1]'
   mutation 'foo[n...-2]'
   mutation 'foo[nil...-1]'
-  mutation 'foo[self...-1]'
 end
 
 Mutant::Meta::Example.add :index do
@@ -90,15 +83,12 @@ Mutant::Meta::Example.add :index do
   mutation 'foo.key?(n..-1)'
   mutation 'self[n..-1]'
   mutation 'foo[nil]'
-  mutation 'foo[self]'
   mutation 'foo[n..nil]'
-  mutation 'foo[n..self]'
   mutation 'foo[n..0]'
   mutation 'foo[n..1]'
   mutation 'foo[n..-2]'
   mutation 'foo[n...-1]'
   mutation 'foo[nil..-1]'
-  mutation 'foo[self..-1]'
   mutation 'foo.drop(n)'
 end
 
@@ -106,7 +96,7 @@ Mutant::Meta::Example.add :index do
   source 'self[foo]'
 
   singleton_mutations
-  mutation 'self[self]'
+  mutation 'self'
   mutation 'self[nil]'
   mutation 'self[]'
   mutation 'self.at(foo)'
@@ -125,9 +115,7 @@ Mutant::Meta::Example.add :index do
   mutation 'foo.fetch(*bar)'
   mutation 'foo.key?(*bar)'
   mutation 'foo[nil]'
-  mutation 'foo[self]'
   mutation 'foo[bar]'
-  mutation 'foo[*self]'
   mutation 'foo[*nil]'
   mutation 'self[*bar]'
 end

--- a/meta/indexasgn.rb
+++ b/meta/indexasgn.rb
@@ -10,10 +10,8 @@ Mutant::Meta::Example.add :indexasgn do
   mutation 'foo.at(bar)'
   mutation 'foo.fetch(bar)'
   mutation 'foo.key?(bar)'
-  mutation 'foo[bar] = self'
   mutation 'foo[bar] = nil'
   mutation 'foo[nil] = baz'
-  mutation 'foo[self] = baz'
   mutation 'foo[] = baz'
   mutation 'baz'
   mutation 'bar'
@@ -25,7 +23,5 @@ Mutant::Meta::Example.add :indexasgn, :op_asgn do
   singleton_mutations
   mutation 'self[] += bar'
   mutation 'self[nil] += bar'
-  mutation 'self[self] += bar'
   mutation 'self[foo] += nil'
-  mutation 'self[foo] += self'
 end

--- a/meta/ivasgn.rb
+++ b/meta/ivasgn.rb
@@ -18,5 +18,4 @@ Mutant::Meta::Example.add :ivasgn do
   mutation '@a &&= 0'
   mutation '@a &&= -1'
   mutation '@a &&= 2'
-  mutation '@a &&= self'
 end

--- a/meta/kwoptarg.rb
+++ b/meta/kwoptarg.rb
@@ -7,7 +7,6 @@ Mutant::Meta::Example.add :kwarg do
   mutation 'def foo(bar: baz); raise; end'
   mutation 'def foo(bar: baz); super; end'
   mutation 'def foo(bar: nil); end'
-  mutation 'def foo(bar: self); end'
   mutation 'def foo(bar:); end'
   mutation 'def foo(_bar: baz); end'
 end

--- a/meta/lambda.rb
+++ b/meta/lambda.rb
@@ -14,7 +14,6 @@ Mutant::Meta::Example.add :block, :lambda do
   singleton_mutations
 
   mutation '->() { }'
-  mutation '->() { self }'
   mutation '->() { nil }'
   mutation '->() { raise }'
   mutation '->() { self.bar }'

--- a/meta/lvar.rb
+++ b/meta/lvar.rb
@@ -6,5 +6,4 @@ Mutant::Meta::Example.add :lvar do
   source 'a'
 
   mutation 'nil'
-  mutation 'self'
 end

--- a/meta/lvasgn.rb
+++ b/meta/lvasgn.rb
@@ -14,11 +14,8 @@ Mutant::Meta::Example.add :array, :lvasgn do
   singleton_mutations
   mutation 'a__mutant__ = *b'
   mutation 'a = nil'
-  mutation 'a = self'
   mutation 'a = []'
   mutation 'a = [nil]'
-  mutation 'a = [self]'
-  mutation 'a = [*self]'
   mutation 'a = [*nil]'
   mutation 'a = [b]'
 end

--- a/meta/op_assgn.rb
+++ b/meta/op_assgn.rb
@@ -10,7 +10,6 @@ Mutant::Meta::Example.add :op_asgn, :send do
   mutation '@a.b += 0'
   mutation '@a.b += 2'
   mutation '@a.b += nil'
-  mutation '@a.b += self'
   mutation 'a.b += 1'
   mutation 'self.b += 1'
 end
@@ -24,7 +23,6 @@ Mutant::Meta::Example.add :op_asgn, :send do
   mutation 'a.b += 0'
   mutation 'a.b += 2'
   mutation 'a.b += nil'
-  mutation 'a.b += self'
   mutation 'self.b += 1'
 end
 
@@ -38,5 +36,4 @@ Mutant::Meta::Example.add :op_asgn, :send do
   mutation 'b += 0'
   mutation 'b += 2'
   mutation 'b += nil'
-  mutation 'b += self'
 end

--- a/meta/or_asgn.rb
+++ b/meta/or_asgn.rb
@@ -6,7 +6,6 @@ Mutant::Meta::Example.add :or_asgn do
   singleton_mutations
   mutation 'a__mutant__ ||= 1'
   mutation 'a ||= nil'
-  mutation 'a ||= self'
   mutation 'a ||= 0'
   mutation 'a ||= -1'
   mutation 'a ||= 2'
@@ -17,7 +16,6 @@ Mutant::Meta::Example.add :or_asgn do
 
   singleton_mutations
   mutation '@a ||= nil'
-  mutation '@a ||= self'
   mutation '@a ||= 0'
   mutation '@a ||= -1'
   mutation '@a ||= 2'
@@ -43,7 +41,6 @@ Mutant::Meta::Example.add :or_asgn do
 
   singleton_mutations
   mutation 'foo[:bar] ||= nil'
-  mutation 'foo[:bar] ||= self'
   mutation 'foo[:bar] ||= 0'
   mutation 'foo[:bar] ||= -1'
   mutation 'foo[:bar] ||= 2'

--- a/meta/range.rb
+++ b/meta/range.rb
@@ -9,9 +9,7 @@ Mutant::Meta::Example.add :irange do
   mutation '0..100'
   mutation '2..100'
   mutation 'nil..100'
-  mutation 'self..100'
   mutation '1..nil'
-  mutation '1..self'
   mutation '1..0'
   mutation '1..1'
   mutation '1..99'
@@ -28,9 +26,7 @@ Mutant::Meta::Example.add :erange do
   mutation '0...100'
   mutation '2...100'
   mutation 'nil...100'
-  mutation 'self...100'
   mutation '1...nil'
-  mutation '1...self'
   mutation '1...0'
   mutation '1...1'
   mutation '1...99'
@@ -47,7 +43,6 @@ unless RUBY_VERSION.start_with?('2.5')
     mutation '0...'
     mutation '2...'
     mutation 'nil...'
-    mutation 'self...'
   end
 
   Mutant::Meta::Example.add :irange do
@@ -58,6 +53,5 @@ unless RUBY_VERSION.start_with?('2.5')
     mutation '0..'
     mutation '2..'
     mutation 'nil..'
-    mutation 'self..'
   end
 end

--- a/meta/regexp.rb
+++ b/meta/regexp.rb
@@ -16,7 +16,6 @@ Mutant::Meta::Example.add :regexp do
   mutation '/#{foo}n/'
   mutation '/#{self.bar}n/'
   mutation '/#{nil}n/'
-  mutation '/#{self}n/'
 end
 
 Mutant::Meta::Example.add :regexp do
@@ -25,7 +24,6 @@ Mutant::Meta::Example.add :regexp do
   singleton_mutations
   regexp_mutations
 
-  mutation '/#{self}/'
   mutation '/#{nil}/'
 end
 
@@ -36,7 +34,6 @@ Mutant::Meta::Example.add :regexp do
   regexp_mutations
 
   mutation '/#{nil}#{nil}/'
-  mutation '/#{self}#{nil}/'
 end
 
 Mutant::Meta::Example.add :regexp do

--- a/meta/regexp/regexp_bos_anchor.rb
+++ b/meta/regexp/regexp_bos_anchor.rb
@@ -14,5 +14,4 @@ Mutant::Meta::Example.add :regexp_bos_anchor do
   regexp_mutations
 
   mutation '/^#{nil}/'
-  mutation '/^#{self}/'
 end

--- a/meta/rescue.rb
+++ b/meta/rescue.rb
@@ -5,8 +5,6 @@ Mutant::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; rescue ExceptionA, ExceptionB; true; end'
-  mutation 'begin; rescue self, ExceptionB => error; true; end'
-  mutation 'begin; rescue ExceptionA, self => error; true; end'
   mutation 'begin; rescue ExceptionA, ExceptionB => error; false; end'
   mutation 'begin; true; end'
 
@@ -18,7 +16,6 @@ Mutant::Meta::Example.add :rescue do
   singleton_mutations
   mutation 'begin; rescue SomeException; true; end'
   mutation 'begin; rescue SomeException => error; false; end'
-  mutation 'begin; rescue self => error; true; end'
   mutation 'begin; true; end'
 end
 
@@ -51,11 +48,8 @@ Mutant::Meta::Example.add :rescue do
 
   # Mutate all bodies
   mutation 'def a; nil;  rescue; bar; else; baz; end'
-  mutation 'def a; self; rescue; bar; else; baz; end'
   mutation 'def a; foo; rescue; nil;  else; baz; end'
-  mutation 'def a; foo; rescue; self; else; baz; end'
   mutation 'def a; foo; rescue; bar; else; nil; end'
-  mutation 'def a; foo; rescue; bar; else; self; end'
 
   # Promote and concat rescue resbody bodies
   mutation 'def a; foo; bar; end'

--- a/meta/return.rb
+++ b/meta/return.rb
@@ -12,5 +12,4 @@ Mutant::Meta::Example.add :return do
   singleton_mutations
   mutation 'foo'
   mutation 'return nil'
-  mutation 'return self'
 end

--- a/meta/sclass.rb
+++ b/meta/sclass.rb
@@ -4,7 +4,6 @@ Mutant::Meta::Example.add :sclass do
   source 'class << self; bar; end'
 
   mutation 'class << self; nil; end'
-  mutation 'class << self; self; end'
 end
 
 Mutant::Meta::Example.add :sclass do

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -8,9 +8,7 @@ Mutant::Meta::Example.add :send do
   mutation 'a.eql?(b)'
   mutation 'a.equal?(b)'
   mutation 'nil > b'
-  mutation 'self > b'
   mutation 'a > nil'
-  mutation 'a > self'
   mutation 'a'
   mutation 'b'
 end
@@ -24,7 +22,6 @@ Mutant::Meta::Example.add :send do
   mutation 'A'
   mutation ':B'
   mutation 'A.const_get(nil)'
-  mutation 'A.const_get(self)'
   mutation 'A.const_get(:B__mutant__)'
   mutation 'self.const_get(:B)'
 end
@@ -37,7 +34,6 @@ Mutant::Meta::Example.add :send do
   mutation 'A'
   mutation 'bar'
   mutation 'A.const_get(nil)'
-  mutation 'A.const_get(self)'
   mutation 'self.const_get(bar)'
 end
 
@@ -49,7 +45,6 @@ Mutant::Meta::Example.add :send do
   mutation 'method'
   mutation 'bar'
   mutation 'method(nil)'
-  mutation 'method(self)'
 end
 
 Mutant::Meta::Example.add :send do
@@ -61,9 +56,7 @@ Mutant::Meta::Example.add :send do
   mutation 'a.eql?(b)'
   mutation 'a.equal?(b)'
   mutation 'nil >= b'
-  mutation 'self >= b'
   mutation 'a >= nil'
-  mutation 'a >= self'
   mutation 'a'
   mutation 'b'
 end
@@ -77,9 +70,7 @@ Mutant::Meta::Example.add :send do
   mutation 'a.eql?(b)'
   mutation 'a.equal?(b)'
   mutation 'nil <= b'
-  mutation 'self <= b'
   mutation 'a <= nil'
-  mutation 'a <= self'
   mutation 'a'
   mutation 'b'
 end
@@ -92,9 +83,7 @@ Mutant::Meta::Example.add :send do
   mutation 'a.eql?(b)'
   mutation 'a.equal?(b)'
   mutation 'nil < b'
-  mutation 'self < b'
   mutation 'a < nil'
-  mutation 'a < self'
   mutation 'a'
   mutation 'b'
 end
@@ -197,9 +186,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'bar'
   mutation 'nil == bar'
-  mutation 'self == bar'
   mutation 'foo == nil'
-  mutation 'foo == self'
   mutation 'foo.eql?(bar)'
   mutation 'foo.equal?(bar)'
 end
@@ -212,7 +199,6 @@ Mutant::Meta::Example.add :send do
   mutation 'bar'
   mutation 'foo.is_a?'
   mutation 'foo.is_a?(nil)'
-  mutation 'foo.is_a?(self)'
   mutation 'self.is_a?(bar)'
   mutation 'foo.instance_of?(bar)'
   mutation 'false'
@@ -227,7 +213,6 @@ Mutant::Meta::Example.add :send do
   mutation 'bar'
   mutation 'foo.kind_of?'
   mutation 'foo.kind_of?(nil)'
-  mutation 'foo.kind_of?(self)'
   mutation 'self.kind_of?(bar)'
   mutation 'foo.instance_of?(bar)'
   mutation 'false'
@@ -244,9 +229,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo.gsub'
   mutation 'foo.sub(a, b)'
   mutation 'foo.gsub(a, nil)'
-  mutation 'foo.gsub(a, self)'
   mutation 'foo.gsub(nil, b)'
-  mutation 'foo.gsub(self, b)'
   mutation 'self.gsub(a, b)'
 end
 
@@ -260,9 +243,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo.values_at(a)'
   mutation 'foo.values_at(b)'
   mutation 'foo.values_at(nil, b)'
-  mutation 'foo.values_at(self, b)'
   mutation 'foo.values_at(a, nil)'
-  mutation 'foo.values_at(a, self)'
   mutation 'foo.values_at'
 end
 
@@ -276,9 +257,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo.dig(a)'
   mutation 'foo.dig(b)'
   mutation 'foo.dig(nil, b)'
-  mutation 'foo.dig(self, b)'
   mutation 'foo.dig(a, nil)'
-  mutation 'foo.dig(a, self)'
   mutation 'foo.dig'
 end
 
@@ -290,7 +269,6 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'self.dig(a)'
   mutation 'foo.dig(nil)'
-  mutation 'foo.dig(self)'
   mutation 'foo.dig'
   mutation 'a'
 end
@@ -313,7 +291,6 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'self.__send__(bar)'
   mutation 'foo.__send__(nil)'
-  mutation 'foo.__send__(self)'
 end
 
 Mutant::Meta::Example.add :send do
@@ -325,7 +302,6 @@ Mutant::Meta::Example.add :send do
   mutation 'public_send(:foo)'
   mutation ':foo'
   mutation '__send__(nil)'
-  mutation '__send__(self)'
   mutation '__send__(:foo__mutant__)'
 end
 
@@ -341,7 +317,6 @@ Mutant::Meta::Example.add :send do
   mutation ':bar'
   mutation 'self.send(:bar)'
   mutation 'foo.send(nil)'
-  mutation 'foo.send(self)'
   mutation 'foo.send(:bar__mutant__)'
 end
 
@@ -354,22 +329,19 @@ Mutant::Meta::Example.add :send do
   mutation 'public_send'
 end
 
-Mutant::Meta::Example.add :send do # rubocop:disable Metrics/BlockLength
+Mutant::Meta::Example.add :send do
   source 'foo.public_send(:bar, 1, two: true, **kwargs, &block)'
 
   singleton_mutations
   mutation 'foo.public_send(:bar, 1, two: true, **kwargs, &nil)'
-  mutation 'foo.public_send(:bar, 1, two: true, **kwargs, &self)'
   mutation 'foo.bar(1, two: true, **kwargs, &block)'
   mutation 'foo'
   mutation 'self.public_send(:bar, 1, two: true, **kwargs, &block)'
   mutation 'foo.public_send'
   mutation 'foo.public_send(nil, 1, two: true, **kwargs, &block)'
-  mutation 'foo.public_send(self, 1, two: true, **kwargs, &block)'
   mutation 'foo.public_send(:bar__mutant__, 1, two: true, **kwargs, &block)'
   mutation 'foo.public_send(1, two: true, **kwargs, &block)'
   mutation 'foo.public_send(:bar, nil, two: true, **kwargs, &block)'
-  mutation 'foo.public_send(:bar, self, two: true, **kwargs, &block)'
   mutation 'foo.public_send(:bar, 0, two: true, **kwargs, &block)'
   mutation 'foo.public_send(:bar, -1, two: true, **kwargs, &block)'
   mutation 'foo.public_send(:bar, 2, two: true, **kwargs, &block)'
@@ -378,7 +350,6 @@ Mutant::Meta::Example.add :send do # rubocop:disable Metrics/BlockLength
   mutation 'foo.public_send(:bar, 1, two: false, **kwargs, &block)'
   mutation 'foo.public_send(:bar, 1, **kwargs, &block)'
   mutation 'foo.public_send(:bar, 1, two: true, **nil, &block)'
-  mutation 'foo.public_send(:bar, 1, two: true, **self, &block)'
   mutation 'foo.public_send(:bar, 1, two: true, &block)'
   mutation 'foo.public_send(:bar, 1, &block)'
   mutation 'foo.public_send(:bar, 1, two: true, **kwargs)'
@@ -395,15 +366,14 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'self.send(bar)'
   mutation 'foo.send(nil)'
-  mutation 'foo.send(self)'
 end
 
 Mutant::Meta::Example.add :send do
   source 'self.booz = baz'
 
   singleton_mutations
+  mutation 'self'
   mutation 'self.booz = nil'
-  mutation 'self.booz = self'
   mutation 'self.booz'
   mutation 'baz'
 end
@@ -414,7 +384,6 @@ Mutant::Meta::Example.add :send do
   singleton_mutations
   mutation 'foo'
   mutation 'foo.booz = nil'
-  mutation 'foo.booz = self'
   mutation 'self.booz = baz'
   mutation 'foo.booz'
   mutation 'baz'
@@ -427,9 +396,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'foo(nil)'
   mutation 'foo(bar)'
-  mutation 'foo(self)'
   mutation 'foo(*nil)'
-  mutation 'foo(*self)'
 end
 
 Mutant::Meta::Example.add :send do
@@ -438,7 +405,6 @@ Mutant::Meta::Example.add :send do
   singleton_mutations
   mutation 'foo'
   mutation 'foo(&nil)'
-  mutation 'foo(&self)'
 end
 
 Mutant::Meta::Example.add :send do
@@ -451,6 +417,7 @@ Mutant::Meta::Example.add :send do
   source 'self.foo'
 
   singleton_mutations
+  mutation 'self'
   mutation 'foo'
 end
 
@@ -459,6 +426,7 @@ Unparser::Constants::KEYWORDS.each do |keyword|
     source "self.#{keyword}"
 
     singleton_mutations
+    mutation 'self'
   end
 end
 
@@ -489,6 +457,7 @@ Mutant::Meta::Example.add :send do
   source 'self.foo(nil)'
 
   singleton_mutations
+  mutation 'self'
   mutation 'self.foo'
   mutation 'foo(nil)'
 end
@@ -497,6 +466,7 @@ Mutant::Meta::Example.add :send do
   source 'self.fetch(nil)'
 
   singleton_mutations
+  mutation 'self'
   mutation 'self.fetch'
   mutation 'fetch(nil)'
   mutation 'self.key?(nil)'
@@ -530,13 +500,9 @@ Mutant::Meta::Example.add :send do
   mutation '(left) / foo'
   mutation '(right) / foo'
   mutation '(left - right) / nil'
-  mutation '(left - right) / self'
   mutation '(left - nil) / foo'
-  mutation '(left - self) / foo'
   mutation '(nil - right) / foo'
-  mutation '(self - right) / foo'
   mutation '(nil) / foo'
-  mutation '(self) / foo'
 end
 
 Mutant::Meta::Example.add :send do
@@ -546,12 +512,9 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'n..-1'
   mutation 'foo(nil)'
-  mutation 'foo(self)'
   mutation 'foo(n...-1)'
   mutation 'foo(nil..-1)'
-  mutation 'foo(self..-1)'
   mutation 'foo(n..nil)'
-  mutation 'foo(n..self)'
   mutation 'foo(n..0)'
   mutation 'foo(n..1)'
   mutation 'foo(n..-2)'
@@ -574,11 +537,9 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'nil != b'
-  mutation 'self != b'
   mutation 'a'
   mutation 'b'
   mutation 'a != nil'
-  mutation 'a != self'
   mutation '!a.eql?(b)'
   mutation '!a.equal?(b)'
 end
@@ -588,8 +549,6 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation '!foo'
-  mutation '!self'
-  mutation '!!self'
   mutation 'foo'
 end
 
@@ -598,7 +557,6 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'foo'
-  mutation '!self'
 end
 
 Mutant::Meta::Example.add :send do
@@ -606,9 +564,7 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'foo&.!'
-  mutation '!self'
   mutation '!foo'
-  mutation '!self&.!'
   mutation '!!foo'
 end
 
@@ -647,7 +603,6 @@ Mutant::Meta::Example.add :send do
   singleton_mutations
   mutation 'a'
   mutation 'nil =~ //'
-  mutation 'self =~ //'
   mutation '//'
   mutation 'a =~ /nomatch\A/'
   mutation 'a.match?(//)'
@@ -658,9 +613,9 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'a'
+  mutation 'self.match(a)'
   mutation '//.match'
   mutation '//.match(nil)'
-  mutation '//.match(self)'
   mutation '//'
   mutation '/nomatch\A/.match(a)'
   mutation '//.match?(a)'
@@ -676,7 +631,6 @@ Mutant::Meta::Example.add :send do
   mutation 'foo(bar { raise })'
   mutation 'foo(bar {})'
   mutation 'foo(bar)'
-  mutation 'foo(self)'
   mutation 'foo(nil)'
 end
 
@@ -687,7 +641,6 @@ Mutant::Meta::Example.add :send do
   mutation 'a'
   mutation 'Array()'
   mutation 'Array(nil)'
-  mutation 'Array(self)'
   mutation '[a]'
 end
 
@@ -700,7 +653,6 @@ Mutant::Meta::Example.add :send do
   mutation 'self.Array(a)'
   mutation 'Kernel.Array'
   mutation 'Kernel.Array(nil)'
-  mutation 'Kernel.Array(self)'
   mutation '[a]'
 end
 
@@ -713,7 +665,6 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'foo.Array'
   mutation 'foo.Array(nil)'
-  mutation 'foo.Array(self)'
 end
 
 Mutant::Meta::Example.add :send do
@@ -733,9 +684,7 @@ Mutant::Meta::Example.add :send do
   mutation 'a'
   mutation 'b'
   mutation 'nil === b'
-  mutation 'self === b'
   mutation 'a === nil'
-  mutation 'a === self'
   mutation 'a.is_a?(b)'
 end
 
@@ -775,7 +724,6 @@ Mutant::Meta::Example.add :send do
 
   mutation 'a'
   mutation 'nil =~ /\Afoo/'
-  mutation 'self =~ /\Afoo/'
   mutation '/\Afoo/'
   mutation 'a =~ //'
   mutation 'a =~ /nomatch\A/'
@@ -790,7 +738,6 @@ Mutant::Meta::Example.add :send do
   mutation 'match?(/\Afoo/)'
   mutation 'match?(1)'
   mutation 'match?(/\Afoo/, nil)'
-  mutation 'match?(/\Afoo/, self)'
   mutation 'match?(/\Afoo/, -1)'
   mutation 'match?(/\Afoo/, 0)'
   mutation 'match?(/\Afoo/, 2)'
@@ -825,4 +772,10 @@ Mutant::Meta::Example.add :send do
   mutation 'a.match(/nomatch\A/)'
   mutation 'self.match(/foo\z/)'
   mutation "a.end_with?('foo')"
+end
+
+Mutant::Meta::Example.add :send do
+  source 'nil.to_f'
+
+  mutation 'nil'
 end

--- a/meta/super.rb
+++ b/meta/super.rb
@@ -21,7 +21,5 @@ Mutant::Meta::Example.add :super do
   mutation 'super(foo)'
   mutation 'super(bar)'
   mutation 'super(foo, nil)'
-  mutation 'super(foo, self)'
   mutation 'super(nil, bar)'
-  mutation 'super(self, bar)'
 end

--- a/meta/until.rb
+++ b/meta/until.rb
@@ -9,8 +9,6 @@ Mutant::Meta::Example.add :until do
   mutation 'until true; end'
   mutation 'until false; foo; bar; end'
   mutation 'until true; foo; nil; end'
-  mutation 'until true; foo; self; end'
   mutation 'until true; nil; bar; end'
-  mutation 'until true; self; bar; end'
   mutation 'until true; raise; end'
 end

--- a/meta/while.rb
+++ b/meta/while.rb
@@ -4,8 +4,6 @@ Mutant::Meta::Example.add :while do
   source 'while true; foo; bar; end'
 
   singleton_mutations
-  mutation 'while true; self; bar; end'
-  mutation 'while true; foo; self; end'
   mutation 'while true; bar; end'
   mutation 'while true; foo; end'
   mutation 'while true; end'

--- a/spec/unit/mutant/meta/example/dsl_spec.rb
+++ b/spec/unit/mutant/meta/example/dsl_spec.rb
@@ -82,10 +82,6 @@ RSpec.describe Mutant::Meta::Example::DSL do
           Mutant::Meta::Example::Expected.new(
             node:            s(:nil),
             original_source: 'nil'
-          ),
-          Mutant::Meta::Example::Expected.new(
-            node:            s(:self),
-            original_source: 'self'
           )
         ]
       end


### PR DESCRIPTION
- This rarely yields an alive mutation and, when it does, it can sometimes be frustrating to avoid or work around. It is also probably a bit confusing to newcomers. Removing this should also make mutant runs shorter since it is a frequently generated mutation.