### PR TITLE
Change unit spec timeout from 2s to 3s

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,7 @@ module XSpecHelper
 end # XSpecHelper
 
 RSpec.configuration.around(file_path: %r{spec/unit}) do |example|
-  Timeout.timeout(2, &example)
+  Timeout.timeout(3, &example)
 end
 
 RSpec.shared_examples_for 'a command method' do


### PR DESCRIPTION
- We are getting fairly regular CI failures where a timeout is hit but will not be hit upon rebuild. Eventually other mechanisms may be superior, but this is a helpful short-term bandaid.