### PR TITLE
Fix regexp mutation p{Latin}

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# v0.10.31 2021-05-03
+
+* [#1234](https://github.com/mbj/mutant/pull/1234)
+  Add mapping for latin regexp properties to fix crash on mutating
+  `p{Latin}` regexp nodes.
+
+  [Fix #1231]
+
 # v0.10.30 2021-04-25
 
 * [#1229](https://github.com/mbj/mutant/pull/1229)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.10.30)
+    mutant (0.10.31)
       diff-lcs (~> 1.3)
       parser (~> 3.0.0)
       regexp_parser (~> 2.0, >= 2.0.3)

--- a/lib/mutant/ast/regexp/transformer.rb
+++ b/lib/mutant/ast/regexp/transformer.rb
@@ -11,7 +11,9 @@ module Mutant
       class Transformer
         include AbstractType
 
-        REGISTRY = Registry.new
+        REGISTRY = Registry.new(
+          ->(type) { fail "No regexp transformer registered for: #{type}" }
+        )
 
         # Lookup transformer class for regular expression node type
         #

--- a/lib/mutant/ast/regexp/transformer/direct.rb
+++ b/lib/mutant/ast/regexp/transformer/direct.rb
@@ -74,6 +74,7 @@ module Mutant
               [:regexp_katakana_property,        [:property,      :katakana,         '\p{Katakana}'], ::Regexp::Expression::UnicodeProperty::Script],
               [:regexp_letter_property,          [:property,      :letter,           '\p{L}'],        ::Regexp::Expression::UnicodeProperty::Letter::Any],
               [:regexp_linebreak_type,           [:type,          :linebreak,        '\R'],           ::Regexp::Expression::CharacterType::Linebreak],
+              [:regexp_latin_property,           [:property,      :latin,            '\p{Latin}'],    ::Regexp::Expression::UnicodeProperty::Script],
               [:regexp_lower_posixclass,         [:posixclass,    :lower,            '[:lower:]'],    ::Regexp::Expression::PosixClass],
               [:regexp_mark_keep,                [:keep,          :mark,             '\K'],           ::Regexp::Expression::Keep::Mark],
               [:regexp_match_start_anchor,       [:anchor,        :match_start,      '\\G'],          ::Regexp::Expression::Anchor::MatchStart],

--- a/lib/mutant/ast/types.rb
+++ b/lib/mutant/ast/types.rb
@@ -107,6 +107,7 @@ module Mutant
         regexp_interval_close_escape
         regexp_interval_open_escape
         regexp_katakana_property
+        regexp_latin_property
         regexp_letter_property
         regexp_linebreak_type
         regexp_literal_escape

--- a/lib/mutant/mutator.rb
+++ b/lib/mutant/mutator.rb
@@ -4,7 +4,7 @@ module Mutant
   # Generator for mutations
   class Mutator
 
-    REGISTRY = Registry.new
+    REGISTRY = Registry.new(->(_) { Node::Generic })
 
     include(
       Adamantium,

--- a/lib/mutant/registry.rb
+++ b/lib/mutant/registry.rb
@@ -3,13 +3,13 @@
 module Mutant
   # Registry for mapping AST types to classes
   class Registry
-    include Concord.new(:contents)
+    include Concord.new(:contents, :default)
 
     # Initialize object
     #
     # @return [undefined]
-    def initialize
-      super({})
+    def initialize(default)
+      super({}, default)
     end
 
     # Raised when the type is an invalid type
@@ -34,7 +34,7 @@ module Mutant
     #
     # @return [Class<Mutator>]
     def lookup(type)
-      contents.fetch(type, Mutator::Node::Generic)
+      contents.fetch(type, &default)
     end
 
   end # Registry

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.10.30'
+  VERSION = '0.10.31'
 end # Mutant

--- a/meta/regexp/regexp_latin_property.rb
+++ b/meta/regexp/regexp_latin_property.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Mutant::Meta::Example.add :regexp, :regexp_latin_property do
+  source('/p{Latin}/')
+
+  singleton_mutations
+  regexp_mutations
+end

--- a/spec/unit/mutant/ast/regexp/transformer_spec.rb
+++ b/spec/unit/mutant/ast/regexp/transformer_spec.rb
@@ -2,7 +2,10 @@
 
 RSpec.describe Mutant::AST::Regexp::Transformer do
   before do
-    stub_const("#{described_class}::REGISTRY", Mutant::Registry.new)
+    stub_const(
+      "#{described_class}::REGISTRY",
+      Mutant::Registry.new(->(_) { fail })
+    )
   end
 
   it 'registers types to a given class' do

--- a/spec/unit/mutant/ast/regexp_spec.rb
+++ b/spec/unit/mutant/ast/regexp_spec.rb
@@ -657,6 +657,11 @@ RegexpSpec.expect_mapping(/\p{Hiragana}/, :regexp_hiragana_property) do
     s(:regexp_hiragana_property))
 end
 
+RegexpSpec.expect_mapping(/\p{Latin}/, :regexp_latin_property) do
+  s(:regexp_root_expression,
+    s(:regexp_latin_property))
+end
+
 RegexpSpec.expect_mapping(/\p{Katakana}/, :regexp_katakana_property) do
   s(:regexp_root_expression,
     s(:regexp_katakana_property))

--- a/spec/unit/mutant/mutator_spec.rb
+++ b/spec/unit/mutant/mutator_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Mutant::Mutator do
   describe '.handle' do
     subject do
       Class.new(described_class) do
-        const_set(:REGISTRY, Mutant::Registry.new)
+        const_set(:REGISTRY, Mutant::Registry.new(->(_) { fail }))
 
         handle :send
 

--- a/spec/unit/mutant/registry_spec.rb
+++ b/spec/unit/mutant/registry_spec.rb
@@ -2,7 +2,9 @@
 
 RSpec.describe Mutant::Registry do
   let(:mutator) { class_double(Mutant::Mutator) }
-  let(:object)  { described_class.new           }
+  let(:object)  { described_class.new(default)  }
+
+  let(:default) { ->(type) { "Default for: #{type.inspect}" } }
 
   describe '#lookup' do
     subject { object.lookup(type) }
@@ -24,7 +26,7 @@ RSpec.describe Mutant::Registry do
       let(:type) { :unknown }
 
       it 'returns genericm mutator' do
-        expect(subject).to be(Mutant::Mutator::Node::Generic)
+        expect(subject).to eql('Default for: :unknown')
       end
     end
   end

--- a/test_app/Gemfile.minitest.lock
+++ b/test_app/Gemfile.minitest.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.10.30)
+    mutant (0.10.31)
       diff-lcs (~> 1.3)
       parser (~> 3.0.0)
       regexp_parser (~> 2.0, >= 2.0.3)
       unparser (~> 0.6.0)
-    mutant-minitest (0.10.30)
+    mutant-minitest (0.10.31)
       minitest (~> 5.11)
-      mutant (= 0.10.30)
+      mutant (= 0.10.31)
 
 GEM
   remote: https://oss:Px2ENN7S91OmWaD5G7MIQJi1dmtmYrEh@gem.mutant.dev/
@@ -21,7 +21,7 @@ GEM
     ast (2.4.2)
     diff-lcs (1.4.4)
     minitest (5.14.4)
-    parser (3.0.1.0)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     regexp_parser (2.1.1)
     unparser (0.6.0)

--- a/test_app/Gemfile.rspec3.8.lock
+++ b/test_app/Gemfile.rspec3.8.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ..
   specs:
-    mutant (0.10.30)
+    mutant (0.10.31)
       diff-lcs (~> 1.3)
       parser (~> 3.0.0)
       regexp_parser (~> 2.0, >= 2.0.3)
       unparser (~> 0.6.0)
-    mutant-rspec (0.10.30)
-      mutant (= 0.10.30)
+    mutant-rspec (0.10.31)
+      mutant (= 0.10.31)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM
@@ -26,7 +26,7 @@ GEM
     ice_nine (0.11.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
-    parser (3.0.1.0)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     regexp_parser (2.1.1)
     rspec (3.8.0)


### PR DESCRIPTION
Fixes the `p{Latin}` regexp constructs that used to crash mutant as reported in #1231.

Also refactor the `Mutant::Registry` class to allow use case specific default behavior, making it easier to address incomplete mappings in the future.