### PR TITLE
Add binmode resets before all IO calls.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# v0.10.32 2021-05-16
+
+* [#1235](https://github.com/mbj/mutant/pull/1235)
+  Add more ugly workaround on Ruby loosing binmode settings.
+
+  [Fix #1228]
+
 # v0.10.31 2021-05-03
 
 * [#1234](https://github.com/mbj/mutant/pull/1234)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.10.31)
+    mutant (0.10.32)
       diff-lcs (~> 1.3)
       parser (~> 3.0.0)
       regexp_parser (~> 2.0, >= 2.0.3)

--- a/lib/mutant/parallel/worker.rb
+++ b/lib/mutant/parallel/worker.rb
@@ -29,9 +29,6 @@ module Mutant
         response = Pipe.from_io(io)
 
         pid = process.fork do
-          request.reset_binmode
-          response.reset_binmode
-
           world.thread.current.name = process_name
           world.process.setproctitle(process_name)
 

--- a/lib/mutant/pipe.rb
+++ b/lib/mutant/pipe.rb
@@ -35,18 +35,6 @@ module Mutant
       reader
     end
 
-    # Set binmode (again)
-    #
-    # Ruby has a bug where the binmode setting may be lost duringa fork.
-    # This API allows to set the binmode again.
-    #
-    # @return [self]
-    def reset_binmode
-      reader.binmode
-      writer.binmode
-      self
-    end
-
     class Connection
       include Anima.new(:marshal, :reader, :writer)
 
@@ -69,6 +57,7 @@ module Mutant
 
           fail Error, 'message to big' if bytesize > MAX_BYTES
 
+          io.binmode
           io.write([bytesize].pack(HEADER_FORMAT))
           io.write(body)
         end
@@ -76,6 +65,7 @@ module Mutant
       private
 
         def read(bytes)
+          io.binmode
           io.read(bytes) or fail Error, 'Unexpected EOF'
         end
       end

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.10.31'
+  VERSION = '0.10.32'
 end # Mutant

--- a/spec/unit/mutant/parallel/worker_spec.rb
+++ b/spec/unit/mutant/parallel/worker_spec.rb
@@ -282,16 +282,6 @@ RSpec.describe Mutant::Parallel::Worker do
           reaction: { yields: [], return: pid }
         },
         {
-          receiver: request_pipe,
-          selector: :reset_binmode,
-          reaction: { return: request_pipe }
-        },
-        {
-          receiver: response_pipe,
-          selector: :reset_binmode,
-          reaction: { return: response_pipe }
-        },
-        {
           receiver: world.thread,
           selector: :current,
           reaction: { return: forked_main_thread }

--- a/spec/unit/mutant/pipe/connection_spec.rb
+++ b/spec/unit/mutant/pipe/connection_spec.rb
@@ -32,12 +32,18 @@ RSpec.describe Mutant::Pipe::Connection do
   end
 
   let(:read_header) do
-    {
-      receiver:  pipe_a.to_reader,
-      selector:  :read,
-      arguments: [4],
-      reaction:  { return: [response_bytes.bytesize].pack('N') }
-    }
+    [
+      {
+        receiver: pipe_a.to_reader,
+        selector: :binmode
+      },
+      {
+        receiver:  pipe_a.to_reader,
+        selector:  :read,
+        arguments: [4],
+        reaction:  { return: [response_bytes.bytesize].pack('N') }
+      }
+    ]
   end
 
   let(:send_request) do
@@ -47,6 +53,10 @@ RSpec.describe Mutant::Pipe::Connection do
         selector:  :dump,
         arguments: [request],
         reaction:  { return: request_bytes }
+      },
+      {
+        receiver: pipe_b.to_writer,
+        selector: :binmode
       },
       {
         receiver:  pipe_b.to_writer,
@@ -63,7 +73,11 @@ RSpec.describe Mutant::Pipe::Connection do
 
   let(:receive_response) do
     [
-      read_header,
+      *read_header,
+      {
+        receiver: pipe_a.to_reader,
+        selector: :binmode
+      },
       {
         receiver:  pipe_a.to_reader,
         selector:  :read,
@@ -132,6 +146,10 @@ RSpec.describe Mutant::Pipe::Connection do
         let(:raw_expectations) do
           [
             {
+              receiver: pipe_a.to_reader,
+              selector: :binmode
+            },
+            {
               receiver:  pipe_a.to_reader,
               selector:  :read,
               arguments: [4],
@@ -150,7 +168,11 @@ RSpec.describe Mutant::Pipe::Connection do
       context 'in body' do
         let(:raw_expectations) do
           [
-            read_header,
+            *read_header,
+            {
+              receiver: pipe_a.to_reader,
+              selector: :binmode
+            },
             {
               receiver:  pipe_a.to_reader,
               selector:  :read,

--- a/spec/unit/mutant/pipe_spec.rb
+++ b/spec/unit/mutant/pipe_spec.rb
@@ -96,29 +96,4 @@ RSpec.describe Mutant::Pipe do
       end
     end
   end
-
-  describe '#reset_binmode' do
-    def apply
-      subject.reset_binmode
-    end
-
-    let(:raw_expectations) do
-      [
-        {
-          receiver: reader,
-          selector: :binmode
-        },
-        {
-          receiver: writer,
-          selector: :binmode
-        }
-      ]
-    end
-
-    it 'returns writer after closing reader' do
-      verify_events do
-        expect(apply).to be(subject)
-      end
-    end
-  end
 end

--- a/test_app/Gemfile.minitest.lock
+++ b/test_app/Gemfile.minitest.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.10.31)
+    mutant (0.10.32)
       diff-lcs (~> 1.3)
       parser (~> 3.0.0)
       regexp_parser (~> 2.0, >= 2.0.3)
       unparser (~> 0.6.0)
-    mutant-minitest (0.10.31)
+    mutant-minitest (0.10.32)
       minitest (~> 5.11)
-      mutant (= 0.10.31)
+      mutant (= 0.10.32)
 
 GEM
   remote: https://oss:Px2ENN7S91OmWaD5G7MIQJi1dmtmYrEh@gem.mutant.dev/

--- a/test_app/Gemfile.rspec3.8.lock
+++ b/test_app/Gemfile.rspec3.8.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ..
   specs:
-    mutant (0.10.31)
+    mutant (0.10.32)
       diff-lcs (~> 1.3)
       parser (~> 3.0.0)
       regexp_parser (~> 2.0, >= 2.0.3)
       unparser (~> 0.6.0)
-    mutant-rspec (0.10.31)
-      mutant (= 0.10.31)
+    mutant-rspec (0.10.32)
+      mutant (= 0.10.32)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM


### PR DESCRIPTION
* I got more and more reports ruby looses this flag, so taking the most
  extreme action here and resetting the binmode before every IO call.