### PR TITLE
Remove support for Ruby-2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0]
+        ruby: [ruby-2.6, ruby-2.7, ruby-3.0]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0]
+        ruby: [ruby-2.6, ruby-2.7, ruby-3.0]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0]
+        ruby: [ruby-2.6, ruby-2.7, ruby-3.0]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0]
+        ruby: [ruby-2.6, ruby-2.7, ruby-3.0]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0]
+        ruby: [ruby-2.6, ruby-2.7, ruby-3.0]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,10 @@
 # v0.10.33 unreleased
 
 * [#1252](https://github.com/mbj/mutant/pull/1252)
-  Remove not universally useful binaryl left negation operator.
+  Remove not universally useful binary left negation operator.
+
+* [#1253](https://github.com/mbj/mutant/pull/1253)
+  Remove support for Ruby-2.5, which is EOL.
 
 # v0.10.33 2021-08-25
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,12 @@ Supported indicates if a specific Ruby version / Implementation is actively supp
 
 | Implementation | Version        | Runtime            | Syntax             | Mutations          | Supported          |
 | -------------- | -------------- | -------            | ------------------ | ------------------ | ------------------ |
-| cRUBY/MRI      | 2.5            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | cRUBY/MRI      | 2.6            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | cRUBY/MRI      | 2.7            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | cRUBY/MRI      | 3.0            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | jruby          | TBD            | :email:            | :email:            | :email:            | :email:            |
 | mruby          | TBD            | :email:            | :email:            | :email:            | :email:            |
-| cRUBY/MRI      | < 2.5          | :no_entry:         | :no_entry:         | :no_entry:         | :no_entry:         |
+| cRUBY/MRI      | < 2.6          | :no_entry:         | :no_entry:         | :no_entry:         | :no_entry:         |
 
 
 Labels:


### PR DESCRIPTION
* This version is EOL since EOL date: 2021-03-31