### PR TITLE
Remove invalid mutations to invalid syntax

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@
 * [#1253](https://github.com/mbj/mutant/pull/1253)
   Remove support for Ruby-2.5, which is EOL.
 
+* [#1255](https://github.com/mbj/mutant/pull/1255)
+  Remove invalid mutations to invalid syntax
+
 # v0.10.33 2021-08-25
 
 * [#1249](https://github.com/mbj/mutant/pull/1249/files)

--- a/lib/mutant/mutator/node/binary.rb
+++ b/lib/mutant/mutator/node/binary.rb
@@ -21,7 +21,11 @@ module Mutant
           emit_singletons
           emit_promotions
           emit_operator_mutations
-          emit_left_mutations
+
+          emit_left_mutations do |mutation|
+            !(n_irange?(mutation) || n_erange?(mutation)) || !mutation.children.fetch(1).nil?
+          end
+
           emit_right_mutations
         end
 

--- a/meta/or.rb
+++ b/meta/or.rb
@@ -23,3 +23,57 @@ Mutant::Meta::Example.add :or do
   mutation 'nil or false'
   mutation 'a__mutant__ = true or false'
 end
+
+Mutant::Meta::Example.add :or do
+  source 'foo(1..) or bar'
+
+  singleton_mutations
+  mutation 'foo(1..)'
+  mutation 'bar'
+  mutation 'foo(1..) && bar'
+  mutation 'nil || bar'
+  mutation 'foo(nil) || bar'
+  mutation 'foo(2..) || bar'
+  mutation 'foo(1..) || nil'
+  mutation 'foo(0..) || bar'
+  mutation 'foo(nil..) || bar'
+  mutation 'foo || bar'
+end
+
+Mutant::Meta::Example.add :or do
+  source 'foo(1..2) or bar'
+
+  singleton_mutations
+  mutation 'foo(1...2) or bar'
+  mutation 'foo(1..2)'
+  mutation '1..2 or bar'
+  mutation 'bar'
+  mutation 'foo(1..2) && bar'
+  mutation 'nil || bar'
+  mutation 'foo(nil) || bar'
+  mutation 'foo(2..2) || bar'
+  mutation 'foo(1..2) || nil'
+  mutation 'foo(0..2) || bar'
+  mutation 'foo(nil..2) || bar'
+  mutation 'foo(1..nil) || bar'
+  mutation 'foo(1..3) || bar'
+  mutation 'foo(1..1) || bar'
+  mutation 'foo(1..0) || bar'
+  mutation 'foo || bar'
+end
+
+Mutant::Meta::Example.add :or do
+  source 'foo(1...) or bar'
+
+  singleton_mutations
+  mutation 'foo(1...)'
+  mutation 'bar'
+  mutation 'foo(1...) && bar'
+  mutation 'nil || bar'
+  mutation 'foo(nil) || bar'
+  mutation 'foo(2...) || bar'
+  mutation 'foo(1...) || nil'
+  mutation 'foo(0...) || bar'
+  mutation 'foo(nil...) || bar'
+  mutation 'foo || bar'
+end


### PR DESCRIPTION
* Rubies syntax is not easily composable in all cases.
* Unparser should NOT make up for cases where mutant emits invalid AST
  (that on the first glance should be valid, as its just promoting
  expressions).