### PR TITLE
Add mutant version to --help output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# v0.10.33 unreleased
+# v0.10.34 2021-08-30
 
 * [#1252](https://github.com/mbj/mutant/pull/1252)
   Remove not universally useful binary left negation operator.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.10.33)
+    mutant (0.10.34)
       diff-lcs (~> 1.3)
       parser (~> 3.0.0)
       regexp_parser (~> 2.0, >= 2.0.3)

--- a/lib/mutant/cli/command.rb
+++ b/lib/mutant/cli/command.rb
@@ -130,6 +130,8 @@ module Mutant
       end
 
       def add_global_options(parser)
+        parser.separator("mutant version: #{VERSION}")
+        parser.separator(nil)
         parser.separator('Global Options:')
         parser.separator(nil)
 

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.10.33'
+  VERSION = '0.10.34'
 end # Mutant

--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -84,10 +84,12 @@ RSpec.describe Mutant::CLI do
     end
 
     def self.main_body
-      <<~'MESSAGE'.strip
+      <<~MESSAGE.strip
         usage: mutant <run|environment|subscription|util> [options]
 
         Summary: mutation testing engine main command
+
+        mutant version: #{Mutant::VERSION}
 
         Global Options:
 
@@ -169,12 +171,14 @@ RSpec.describe Mutant::CLI do
     end
 
     make do
-      message = <<~'MESSAGE'
+      message = <<~MESSAGE
         mutant subscription: Missing required subcommand!
 
         usage: mutant subscription <show|test> [options]
 
         Summary: Subscription subcommands
+
+        mutant version: #{Mutant::VERSION}
 
         Global Options:
 
@@ -207,10 +211,12 @@ RSpec.describe Mutant::CLI do
     end
 
     make do
-      message = <<~'MESSAGE'
+      message = <<~MESSAGE
         usage: mutant subscription show [options]
 
         Summary: Show subscription status
+
+        mutant version: #{Mutant::VERSION}
 
         Global Options:
 
@@ -227,10 +233,12 @@ RSpec.describe Mutant::CLI do
     end
 
     make do
-      message = <<~'MESSAGE'
+      message = <<~MESSAGE
         usage: mutant run [options]
 
         Summary: Run code analysis
+
+        mutant version: #{Mutant::VERSION}
 
         Global Options:
 
@@ -269,10 +277,12 @@ RSpec.describe Mutant::CLI do
     end
 
     make do
-      message = <<~'MESSAGE'
+      message = <<~MESSAGE
         usage: mutant util <mutation> [options]
 
         Summary: Utility subcommands
+
+        mutant version: #{Mutant::VERSION}
 
         Global Options:
 
@@ -293,10 +303,12 @@ RSpec.describe Mutant::CLI do
     end
 
     make do
-      message = <<~'MESSAGE'
+      message = <<~MESSAGE
         usage: mutant util mutation [options]
 
         Summary: Print mutations of a code snippet
+
+        mutant version: #{Mutant::VERSION}
 
         Global Options:
 


### PR DESCRIPTION
* This reduces one cycle on customer support. Where people post an
  argument error parsing issue.