### PR TITLE
Change to improved matching speed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # v.0.11.1 2021-11-xx
 
+* [#1276](https://github.com/mbj/mutant/pull/1276)
+
+  Improve matching speed. This is especiablly noticable in lager projects.
+  Mutant now creates way less objects while matching subjects.
+
 * [#1275](https://github.com/mbj/mutant/pull/1275)
 
   Fix: [#1273](https://github.com/mbj/mutant/issues/1273)

--- a/lib/mutant/matcher/methods.rb
+++ b/lib/mutant/matcher/methods.rb
@@ -40,7 +40,7 @@ module Mutant
 
       def candidate_names
         CANDIDATE_NAMES
-          .map { |name| candidate_scope.public_send(name) }
+          .map { |name| candidate_scope.public_send(name, false) }
           .reduce(:+)
           .sort
       end

--- a/spec/unit/mutant/matcher/methods/instance_spec.rb
+++ b/spec/unit/mutant/matcher/methods/instance_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe Mutant::Matcher::Methods::Instance, '#call' do
 
     let(:scope) do
       Class.new do
-        def self.public_instance_methods
+        def self.public_instance_methods(ancestors)
+          fail if ancestors
           %i[foo]
         end
       end


### PR DESCRIPTION
* At the time of Ruby 1.9 had to contnet with less coherent method
  reflection. And thus was not limiting the methods per scope.
* These days the reflection interfaces are better and so not checking
  the anchestors allows a small speed boost on matching.