### PR TITLE
Fix various typos

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 * [#1276](https://github.com/mbj/mutant/pull/1276)
 
-  Improve matching speed. This is especiablly noticable in lager projects.
+  Improve matching speed. This is especiablly noticeable in larger projects.
   Mutant now creates way less objects while matching subjects.
 
 * [#1275](https://github.com/mbj/mutant/pull/1275)
@@ -10,7 +10,7 @@
   Fix: [#1273](https://github.com/mbj/mutant/issues/1273)
 
   Prevent crashes on degenerate object interfaces where method reflection returns
-  methods that are later not accessible via `#instnace_method`.
+  methods that are later not accessible via `#instance_method`.
 
 * [#1274](https://github.com/mbj/mutant/pull/1274)
 
@@ -398,7 +398,7 @@
 
 # v0.10.2 2020-11-02
 
-* Fix type error on subscription show subcommand whith active commercial license.
+* Fix type error on subscription show subcommand with active commercial license.
   [#1074](https://github.com/mbj/mutant/pull/1084)
 
 # v0.10.1 2020-10-29

--- a/docs/commercial.md
+++ b/docs/commercial.md
@@ -86,7 +86,7 @@ separate and individuall developers cannot update the subscription.
 Can I get a refund?
 -------------------
 
-Yes, for monthly subscription the **last payed month** gets refunded on cancellation.
+Yes, for monthly subscription the **last paid month** gets refunded on cancellation.
 Email [mbj@schirp-dso](mailto:mbj@schirp-dso.com).
 
 How do I update my info?

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ Additional environment variables can be added by providing the `--env KEY=VALUE`
 
 #### `integration`
 
-Specifies which mutant integration to use. If your tests are writen in [RSpec](https://rspec.info/), this should be set to `rspec`. If your tests are written in [minitest](https://github.com/seattlerb/minitest), this should be set to `minitest`.
+Specifies which mutant integration to use. If your tests are written in [RSpec](https://rspec.info/), this should be set to `rspec`. If your tests are written in [minitest](https://github.com/seattlerb/minitest), this should be set to `minitest`.
 
 ```yml
 ---

--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -1050,13 +1050,13 @@ RSpec.describe Mutant::CLI do
           let(:env_config)       { Mutant::Config::DEFAULT }
           let(:file_config)      { Mutant::Config::DEFAULT }
 
-          context 'without coverage criterias in env or file' do
+          context 'without coverage criteria in env or file' do
             let(:bootstrap_config) { Mutant::Config::DEFAULT.expand_defaults }
 
             include_examples 'CLI run'
           end
 
-          context 'with coverage criterias in file' do
+          context 'with coverage criteria in file' do
             let(:file_config) do
               Mutant::Config::DEFAULT.with(
                 coverage_criteria: Mutant::Config::CoverageCriteria::DEFAULT.with(

--- a/spec/unit/mutant/config_spec.rb
+++ b/spec/unit/mutant/config_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe Mutant::Config do
     end
   end
 
-  describe '.parse_enviroment_variables' do
+  describe '.parse_environment_variables' do
     def apply
       described_class.parse_environment_variables(input)
     end

--- a/spec/unit/mutant/isolation/fork_spec.rb
+++ b/spec/unit/mutant/isolation/fork_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Mutant::Isolation::Fork do
         context 'when child terminates immediately' do
           let(:post_reads) { [child_nowait(child_status_success)] }
 
-          it 'returns sucess result' do
+          it 'returns success result' do
             verify_events do
               expect(apply).to eql(
                 described_class::Result.new(

--- a/spec/unit/mutant/reporter/cli/printer/isolation_result_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/isolation_result_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::IsolationResult do
       STR
     end
 
-    context 'on unsucessful process status' do
+    context 'on unsuccessful process status' do
       let(:process_status) do
         instance_double(Process::Status, 'unsuccessful status', success?: false)
       end


### PR DESCRIPTION
- A couple of these I just happened to notice while looking at the changelog
- For the remainder, I used the excellent [misspell](https://github.com/client9/misspell) tool. It might make sense to add it as a build step for mutant.