### PR TITLE
Disable case else branch for `T.absurd`

### DIFF
--- a/lib/mutant/ast/meta/send.rb
+++ b/lib/mutant/ast/meta/send.rb
@@ -8,12 +8,14 @@ module Mutant
       # Metadata for send nodes
       class Send
         include NamedChildren, Concord.new(:node), NodePredicates
+        extend Sexp
 
         children :receiver, :selector
 
         public :receiver, :selector
 
         ATTRIBUTE_ASSIGNMENT_SELECTOR_SUFFIX = '='
+        SORBET_RECEIVERS = [s(:const, nil, :T), s(:const, s(:cbase), :T)].freeze
 
         # Arguments of mutated node
         #
@@ -27,6 +29,13 @@ module Mutant
         # @return [Boolean]
         def proc?
           naked_proc? || proc_new?
+        end
+
+        # Test if message receiver is :T
+        #
+        # @return [Boolean]
+        def sorbet_receiver?
+          SORBET_RECEIVERS.include?(receiver)
         end
 
         # Test if AST node is a valid attribute assignment

--- a/lib/mutant/mutator/node/case.rb
+++ b/lib/mutant/mutator/node/case.rb
@@ -33,6 +33,8 @@ module Mutant
           else_branch = children.last
           else_index = children.length - 1
           return unless else_branch
+          return if else_branch.eql?(s(:send, s(:const, nil, :T), :absurd))
+
           mutate_child(else_index)
           emit_child_update(else_index, nil)
         end

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -57,6 +57,8 @@ module Mutant
       private
 
         def dispatch
+          return if meta.sorbet_receiver?
+
           emit_singletons
 
           if meta.binary_method_operator?

--- a/meta/sorbet.rb
+++ b/meta/sorbet.rb
@@ -7,3 +7,30 @@ end
 Mutant::Meta::Example.add :send do
   source '::T.must(a > b)'
 end
+
+Mutant::Meta::Example.add :case do
+  source <<~RUBY
+    case
+    when true
+    else
+      T.absurd(true)
+    end
+  RUBY
+
+  singleton_mutations
+
+  mutation <<-RUBY
+    case
+    when true
+      raise
+    else T.absurd(true)
+    end
+  RUBY
+
+  mutation <<-RUBY
+    case
+    when false
+    else T.absurd(true)
+    end
+  RUBY
+end

--- a/meta/sorbet.rb
+++ b/meta/sorbet.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Mutant::Meta::Example.add :send do
+  source 'T.must(a > b)'
+end
+
+Mutant::Meta::Example.add :send do
+  source '::T.must(a > b)'
+end


### PR DESCRIPTION
Merging this PR will make `mutant` ignore else branches for case statments when their content is a call to `T.absurd`.
