### PR TITLE
Remove unused `let`s and `shared_examples`

### DIFF
--- a/spec/unit/mutant/bootstrap_spec.rb
+++ b/spec/unit/mutant/bootstrap_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Mutant::Bootstrap do
   let(:load_path)            { instance_double(Array, :load_path)     }
   let(:match_warnings)       { []                                     }
   let(:object_space)         { class_double(ObjectSpace)              }
-  let(:object_space_modules) { []                                     }
   let(:start_expressions)    { []                                     }
   let(:subject_expressions)  { []                                     }
   let(:timer)                { instance_double(Mutant::Timer)         }

--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -472,12 +472,10 @@ RSpec.describe Mutant::CLI do
       let(:bootstrap_config)     { env_config.merge(file_config).expand_defaults        }
       let(:bootstrap_result)     { right(env)                                           }
       let(:env_result)           { instance_double(Mutant::Result::Env, success?: true) }
-      let(:expected_events)      { [license_validation_event]                           }
       let(:expected_exit)        { true                                                 }
       let(:file_config_result)   { right(file_config)                                   }
       let(:license_result)       { right(subscription)                                  }
       let(:runner_result)        { right(env_result)                                    }
-      let(:subject_a_expression) { parse_expression('Object#send')                      }
       let(:subjects)             { [subject_a]                                          }
       let(:tests)                { [test_a, test_b]                                     }
 

--- a/spec/unit/mutant/expression/descendants_spec.rb
+++ b/spec/unit/mutant/expression/descendants_spec.rb
@@ -2,7 +2,6 @@
 
 RSpec.describe Mutant::Expression::Descendants do
   let(:object) { parse_expression(input)    }
-  let(:env)    { Fixtures::TEST_ENV         }
   let(:input)  { 'descendants:TestApp::Foo' }
 
   describe '#matcher' do

--- a/spec/unit/mutant/meta/example_spec.rb
+++ b/spec/unit/mutant/meta/example_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Mutant::Meta::Example do
     )
   end
 
-  let(:file)           { 'foo/bar.rb' }
   let(:node)           { s(:true)     }
   let(:mutation_nodes) { [s(:false)]  }
 

--- a/spec/unit/mutant/repository/diff_spec.rb
+++ b/spec/unit/mutant/repository/diff_spec.rb
@@ -12,7 +12,6 @@ describe Mutant::Repository::Diff do
     let(:line_range) { 4..5                        }
     let(:path)       { Pathname.new('/foo/bar.rb') }
     let(:pathname)   { class_double(Pathname)      }
-    let(:repo_root)  { Pathname.new('/foo')        }
 
     let(:world) do
       instance_double(

--- a/spec/unit/mutant/subject/method/instance_spec.rb
+++ b/spec/unit/mutant/subject/method/instance_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Mutant::Subject::Method::Instance do
     )
   end
 
-  let(:call_block?) { true                              }
-  let(:node)        { Unparser.parse('def foo; end')    }
+  let(:node) { Unparser.parse('def foo; end') }
 
   let(:context) do
     Mutant::Context.new(
@@ -88,21 +87,6 @@ RSpec.describe Mutant::Subject::Method::Instance::Memoized do
 
         def self.name
           'MemoizableClass'
-        end
-
-        def foo; end
-        memoize :foo
-      end
-    end
-  end
-
-  shared_context 'adamantium scope setup' do
-    let(:scope) do
-      Class.new do
-        include Unparser::Adamantium
-
-        def self.name
-          'AdamantiumClass'
         end
 
         def foo; end

--- a/spec/unit/mutant/timer/deadline_spec.rb
+++ b/spec/unit/mutant/timer/deadline_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe Mutant::Timer::Deadline do
       object.expired?
     end
 
-    let(:allowed_time) { 1.0 }
-
     context 'when deadline has not yet expired' do
       let(:allowed_time) { 1.5 }
 
@@ -78,8 +76,6 @@ RSpec.describe Mutant::Timer::Deadline do
     def apply
       object.status
     end
-
-    let(:allowed_time) { 1.0 }
 
     context 'when deadline has not yet expired' do
       let(:allowed_time) { 1.5 }


### PR DESCRIPTION
- Discovered while testing a new release of [rspectre](https://github.com/dgollahon/rspectre)