### PR TITLE
Remove ruby-2.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.6, ruby-2.7, ruby-3.0, ruby-3.1]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.6, ruby-2.7, ruby-3.0, ruby-3.1]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.6, ruby-2.7, ruby-3.0, ruby-3.1]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.6, ruby-2.7, ruby-3.0, ruby-3.1]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.6, ruby-2.7, ruby-3.0, ruby-3.1]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.6, ruby-2.7, ruby-3.0, ruby-3.1]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   # This is output on every run of `rubocop` and feels fairly noisy.
   SuggestExtensions: false
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # v0.11.5 unreleased
 
+* [#1310](https://github.com/mbj/mutant/pull/1310)
+
+  Remove support for Ruby-2.6 as its EOL.
+
 * [#1309](https://github.com/mbj/mutant/pull/1309)
 
   Change to ignore case mismatches in git repository names on license check.

--- a/README.md
+++ b/README.md
@@ -58,13 +58,12 @@ Supported indicates if a specific Ruby version / Implementation is actively supp
 
 | Implementation | Version        | Runtime            | Syntax             | Mutations          | Supported          |
 | -------------- | -------------- | -------            | ------------------ | ------------------ | ------------------ |
-| cRUBY/MRI      | 2.6            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | cRUBY/MRI      | 2.7            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | cRUBY/MRI      | 3.0            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | cRUBY/MRI      | 3.1            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | jruby          | TBD            | :email:            | :email:            | :email:            | :email:            |
 | mruby          | TBD            | :email:            | :email:            | :email:            | :email:            |
-| cRUBY/MRI      | < 2.6          | :no_entry:         | :no_entry:         | :no_entry:         | :no_entry:         |
+| cRUBY/MRI      | < 2.7          | :no_entry:         | :no_entry:         | :no_entry:         | :no_entry:         |
 
 
 Labels:

--- a/mutant-minitest.gemspec
+++ b/mutant-minitest.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.extra_rdoc_files = %w[LICENSE]
 
-  gem.required_ruby_version = '>= 2.6'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.add_runtime_dependency('minitest', '~> 5.11')
   gem.add_runtime_dependency('mutant',   "= #{gem.version}")

--- a/mutant-rspec.gemspec
+++ b/mutant-rspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files            = %w[lib/mutant/integration/rspec.rb]
   gem.extra_rdoc_files = %w[LICENSE]
 
-  gem.required_ruby_version = '>= 2.6'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.add_runtime_dependency('mutant', "= #{gem.version}")
   gem.add_runtime_dependency('rspec-core', '>= 3.8.0', '< 4.0.0')

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[LICENSE]
   gem.executables      = %w[mutant]
 
-  gem.required_ruby_version = '>= 2.6'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.add_runtime_dependency('diff-lcs',       '~> 1.3')
   gem.add_runtime_dependency('parser',         '~> 3.1.0')


### PR DESCRIPTION
* Its EOL, if you are affected support for EOL releases is not included
  in commercial licenses, needs custom support agreement.