### PR TITLE
[WIP] Failing tests for backref calls

### DIFF
--- a/meta/regexp.rb
+++ b/meta/regexp.rb
@@ -1,5 +1,143 @@
 # frozen_string_literal: true
 
+# Generated based on: https://github.com/ammar/regexp_parser/blob/311f70f8b4c3fbd99129846294bbd330ba538622/spec/lexer/refcalls_spec.rb
+Mutant::Meta::Example.add :regexp do
+  source '/(?<X>abc)\k<X>/'
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source '/(abc)\k<1>/'
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source "/(abc)\\k'1'/"
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source '/(abc)\k<-1>/'
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source "/(abc)\\k'-1'/"
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source '/(?<X>abc)\g<X>/'
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source "/(?<X>abc)\\g'X'/"
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source '/(abc)\g<1>/'
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source "/(abc)\\g'1'/"
+
+  singleton_mutations
+  regexp_mutations
+end
+
+# ## NOTE: This example seems to be an invalid regexp. I've included it for completeness.
+# Mutant::Meta::Example.add :regexp do
+#   source '/\g<0>/'
+
+#   singleton_mutations
+#   regexp_mutations
+# end
+
+# ## NOTE: This example seems to be an invalid regexp. I've included it for completeness.
+# Mutant::Meta::Example.add :regexp do
+#   source "/\\g'0'/"
+
+#   singleton_mutations
+#   regexp_mutations
+# end
+
+Mutant::Meta::Example.add :regexp do
+  source '/(abc)\g<-1>/'
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source "/(abc)\\g'-1'/"
+
+  singleton_mutations
+  regexp_mutations
+end
+
+# ## NOTE: This example seems to be an invalid regexp. I've included it for completeness.
+# Mutant::Meta::Example.add :regexp do
+#   source '/(abc)\g<+1>/'
+
+#   singleton_mutations
+#   regexp_mutations
+# end
+
+# ## NOTE: This example seems to be an invalid regexp. I've included it for completeness.
+# Mutant::Meta::Example.add :regexp do
+#   source "/(abc)\\g'+1'/"
+
+#   singleton_mutations
+#   regexp_mutations
+# end
+
+Mutant::Meta::Example.add :regexp do
+  source '/(?<X>abc)\k<X-0>/'
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source "/(?<X>abc)\\k'X-0'/"
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source '/(abc)\k<1-0>/'
+
+  singleton_mutations
+  regexp_mutations
+end
+
+Mutant::Meta::Example.add :regexp do
+  source "/(abc)\\k'1-0'/"
+
+  singleton_mutations
+  regexp_mutations
+end
+
 Mutant::Meta::Example.add :regexp do
   source '/foo/'
 


### PR DESCRIPTION
These all independently crash the unit tests.

I left 4 tests commented out since they seem to be invalid regexps, but there still may be a need to map them. I'm not sure how to construct a valid example off the top of my head.

It might make sense to try to auto-generate regexp specs based off of the calls to [shared examples](https://github.com/ammar/regexp_parser/blob/master/spec/support/shared_examples.rb) in the regexp parser spec files.