### PR TITLE
Improve procarg0 handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- [#1326](https://github.com/mbj/mutant/pull/1326)
+
+  Fix crash with certain block argument edge cases such as `foo { |(*)| }`.
+
+  Fix mutation from `foo { |(a, b)| }` to `foo { |(_a, b)| }` and `foo { |(a, _b)| }` instead of the less useful mutation to only `foo { |_a| }`.
+
 * [#1324](https://github.com/mbj/mutant/pull/1324)
   
   Remove useless `loop { code }` -> `loop { nil }` mutation.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 
   Fix mutation from `foo { |(a, b)| }` to `foo { |(_a, b)| }` and `foo { |(a, _b)| }` instead of the less useful mutation to only `foo { |_a| }`.
 
+  Add `foo { |(a, b)| }` -> `foo { |a, b| }` mutation.
+
 * [#1324](https://github.com/mbj/mutant/pull/1324)
   
   Remove useless `loop { code }` -> `loop { nil }` mutation.

--- a/lib/mutant/ast/meta/optarg.rb
+++ b/lib/mutant/ast/meta/optarg.rb
@@ -19,7 +19,7 @@ module Mutant
         #
         # @return [Boolean]
         def used?
-          !name.to_s.start_with?(UNDERSCORE)
+          !name.start_with?(UNDERSCORE)
         end
       end # Optarg
 

--- a/lib/mutant/mutator/node/argument.rb
+++ b/lib/mutant/mutator/node/argument.rb
@@ -24,7 +24,7 @@ module Mutant
         end
 
         def skip?
-          name.to_s.start_with?(UNDERSCORE)
+          name.start_with?(UNDERSCORE)
         end
 
         # Mutator for optional arguments

--- a/lib/mutant/mutator/node/arguments.rb
+++ b/lib/mutant/mutator/node/arguments.rb
@@ -16,6 +16,7 @@ module Mutant
           emit_argument_presence
           emit_argument_mutations
           emit_mlhs_expansion
+          emit_procarg0_removal
         end
 
         def emit_argument_presence
@@ -73,6 +74,13 @@ module Mutant
           children.each_with_index.select do |child,|
             n_mlhs?(child)
           end
+        end
+
+        def emit_procarg0_removal
+          return unless children.one? && n_procarg0?((procarg0 = Mutant::Util.one(children)))
+
+          arguments = procarg0.children
+          emit_type(*arguments) if arguments.count > 1
         end
 
       end # Arguments

--- a/lib/mutant/mutator/node/procarg_zero.rb
+++ b/lib/mutant/mutator/node/procarg_zero.rb
@@ -7,14 +7,10 @@ module Mutant
 
         handle :procarg0
 
-        children :argument
-
       private
 
         def dispatch
-          name = Mutant::Util.one(argument.children)
-
-          emit_type(s(:arg, :"_#{name}")) unless name.start_with?('_')
+          children.each_index(&method(:mutate_child))
         end
       end # ProcargZero
     end # Node

--- a/lib/mutant/mutator/node/procarg_zero.rb
+++ b/lib/mutant/mutator/node/procarg_zero.rb
@@ -14,7 +14,7 @@ module Mutant
         def dispatch
           name = Mutant::Util.one(argument.children)
 
-          emit_type(s(:arg, :"_#{name}")) unless name.to_s.start_with?('_')
+          emit_type(s(:arg, :"_#{name}")) unless name.start_with?('_')
         end
       end # ProcargZero
     end # Node

--- a/meta/procarg_zero.rb
+++ b/meta/procarg_zero.rb
@@ -33,6 +33,7 @@ Mutant::Meta::Example.add :procarg0 do
   source 'foo { |(a, b)| }'
 
   singleton_mutations
+  mutation 'foo { |a, b| }'
   mutation 'foo { |(a, b)| raise }'
   mutation 'foo { |(_a, b)| }'
   mutation 'foo { |(a, _b)| }'
@@ -53,6 +54,7 @@ Mutant::Meta::Example.add :procarg0 do
   source 'foo { |(a, (*))| }'
 
   singleton_mutations
+  mutation 'foo { |a, (*)| }'
   mutation 'foo { |(a, (*))| raise }'
   mutation 'foo { |(_a, (*))| }'
   mutation 'foo { }'

--- a/meta/procarg_zero.rb
+++ b/meta/procarg_zero.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+Mutant::Meta::Example.add :procarg0 do
+  source 'foo { |a| }'
+
+  singleton_mutations
+  mutation 'foo { |a| raise }'
+  mutation 'foo { |_a| }'
+  mutation 'foo { }'
+  mutation 'foo'
+end
+
+Mutant::Meta::Example.add :procarg0 do
+  source 'foo { |_a| }'
+
+  singleton_mutations
+  mutation 'foo { |_a| raise }'
+  mutation 'foo { }'
+  mutation 'foo'
+end
+
+Mutant::Meta::Example.add :procarg0 do
+  source 'foo { |(a)| }'
+
+  singleton_mutations
+  mutation 'foo { |(a)| raise }'
+  mutation 'foo { |(_a)| }'
+  mutation 'foo { }'
+  mutation 'foo'
+end
+
+Mutant::Meta::Example.add :procarg0 do
+  source 'foo { |(a, b)| }'
+
+  singleton_mutations
+  mutation 'foo { |(a, b)| raise }'
+  # This mutation is a bug--it doesn't make sense to promote the entire arguments to the first mlhs
+  # argument. This is meant to show that `a` is unused but that is not what is happening here. We
+  # are also missing the underscoring of `_b` .
+  mutation 'foo { |_a| }'
+  mutation 'foo { }'
+  mutation 'foo'
+end

--- a/meta/procarg_zero.rb
+++ b/meta/procarg_zero.rb
@@ -34,10 +34,27 @@ Mutant::Meta::Example.add :procarg0 do
 
   singleton_mutations
   mutation 'foo { |(a, b)| raise }'
-  # This mutation is a bug--it doesn't make sense to promote the entire arguments to the first mlhs
-  # argument. This is meant to show that `a` is unused but that is not what is happening here. We
-  # are also missing the underscoring of `_b` .
-  mutation 'foo { |_a| }'
+  mutation 'foo { |(_a, b)| }'
+  mutation 'foo { |(a, _b)| }'
+  mutation 'foo { }'
+  mutation 'foo'
+end
+
+Mutant::Meta::Example.add :procarg0 do
+  source 'foo { |(*)| }'
+
+  singleton_mutations
+  mutation 'foo { |(*)| raise }'
+  mutation 'foo { }'
+  mutation 'foo'
+end
+
+Mutant::Meta::Example.add :procarg0 do
+  source 'foo { |(a, (*))| }'
+
+  singleton_mutations
+  mutation 'foo { |(a, (*))| raise }'
+  mutation 'foo { |(_a, (*))| }'
   mutation 'foo { }'
   mutation 'foo'
 end

--- a/mutant.yml
+++ b/mutant.yml
@@ -11,8 +11,6 @@ matcher:
   - Mutant*
   ignore:
   - Mutant::Isolation::Fork::Parent#call
-  - Mutant::Mutator::Node::Argument#skip?
-  - Mutant::Mutator::Node::ProcargZero#dispatch
   - Mutant::Zombifier#call
   # Mutation only alive for ruby < 3.1
   - Mutant::Mutator::Node::Arguments#anonymous_block_arg?

--- a/mutant.yml
+++ b/mutant.yml
@@ -13,11 +13,7 @@ matcher:
   - Mutant::Isolation::Fork::Parent#call
   - Mutant::Mutator::Node::Argument#skip?
   - Mutant::Mutator::Node::ProcargZero#dispatch
-  - Mutant::Mutator::Node::When#mutate_conditions
   - Mutant::Zombifier#call
-  # Mutation only alive for Ruby <2.7
-  - Mutant::Mutator::Node::Literal::Range#dispatch
-  - Mutant::Mutator::Node::Numblock#dispatch
   # Mutation only alive for ruby < 3.1
   - Mutant::Mutator::Node::Arguments#anonymous_block_arg?
   - Mutant::Mutator::Node::Arguments#emit_argument_presence

--- a/spec/support/corpus.rb
+++ b/spec/support/corpus.rb
@@ -139,7 +139,7 @@ module MutantSpec
       #
       # @return [Integer] mutations generated
       def check_generation(path)
-        node = Parser::CurrentRuby.parse(path.read) or return 0
+        node = Unparser.parse(path.read) or return 0
 
         mutations = Mutant::Mutator.mutate(node)
 


### PR DESCRIPTION
This PR does several things, all motivated by improving procarg0 support:
- Cleans up some mutant ignores
  - NOTE: Makes reliance on 2.7+ slightly tighter. Not sure if that affects any custom support cases.
- Fixes crash with certain block argument edge cases such as `foo { |(*)| }`.
- Fixes mutation from `foo { |(a, b)| }` to `foo { |(_a, b)| }` and `foo { |(a, _b)| }` instead of the less useful mutation to only `foo { |_a| }`.
- Adds a `foo { |(a, b)| }` -> `foo { |a, b| }` mutation.
- Fixes corpus tests which were previously not testing the modern `parser` AST