### PR TITLE
Fix named group mutations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* [#1328](https://github.com/mbj/mutant/pull/1328)
+
+  Fix incomplete mutations for named regexp capture groups. As an example, `/(?<name>\w\d)/` now gets mutated to `/(?<name>\W\d)/` and `/(?<name>\w\D)/` instead of just the former case.
+
 # v0.11.9 2022-05-01
 
 * [#1327](https://github.com/mbj/mutant/pull/1327)

--- a/lib/mutant/mutator/node/regexp/named_group.rb
+++ b/lib/mutant/mutator/node/regexp/named_group.rb
@@ -8,25 +8,25 @@ module Mutant
         class NamedGroup < Node
           handle(:regexp_named_group)
 
-          children :name, :group
+          children :name
 
         private
 
           def dispatch
-            return unless group
+            return if remaining_children.empty?
 
-            emit_group_mutations
+            remaining_children_indices.each(&method(:mutate_child))
 
             # Allows unused captures to be kept and named if they are explicitly prefixed with an
             # underscore, like we allow with unused local variables.
             return if name_underscored?
 
-            emit(s(:regexp_passive_group, group))
+            emit(s(:regexp_passive_group, *remaining_children))
             emit_name_underscore_mutation
           end
 
           def emit_name_underscore_mutation
-            emit_type("_#{name}", group)
+            emit_type("_#{name}", *remaining_children)
           end
 
           def name_underscored?

--- a/meta/regexp/regexp_named_group.rb
+++ b/meta/regexp/regexp_named_group.rb
@@ -19,10 +19,10 @@ Mutant::Meta::Example.add :regexp_named_group do
 end
 
 Mutant::Meta::Example.add :regexp_named_group do
-  source '/(?<_foo>\w)/'
+  source '/(?<_foo>\w\d)/'
 
   singleton_mutations
   regexp_mutations
 
-  mutation '/(?<_foo>\W)/'
+  mutation '/(?<_foo>\W\d)/'
 end

--- a/meta/regexp/regexp_named_group.rb
+++ b/meta/regexp/regexp_named_group.rb
@@ -25,4 +25,5 @@ Mutant::Meta::Example.add :regexp_named_group do
   regexp_mutations
 
   mutation '/(?<_foo>\W\d)/'
+  mutation '/(?<_foo>\w\D)/'
 end


### PR DESCRIPTION
- Regular expressions such as `/(?<name>\w\d)/` would only end up mutating the part of the group (ex: `/(?<name>\W\d)/` but not `/(?<name>\w\D)/`). This change fixes that error and mutates over all children of the named capture group.