### PR TITLE
Add graceful exit on SIGINT

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,12 @@
-# Unreleased
+# v0.11.10 2022-05-02
 
 * [#1328](https://github.com/mbj/mutant/pull/1328)
 
   Fix incomplete mutations for named regexp capture groups. As an example, `/(?<name>\w\d)/` now gets mutated to `/(?<name>\W\d)/` and `/(?<name>\w\D)/` instead of just the former case.
+
+* [#1331](https://github.com/mbj/mutant/pull/1331)
+
+  Add graceful but urgent exit on SIGINT.
 
 # v0.11.9 2022-05-01
 

--- a/lib/mutant/runner.rb
+++ b/lib/mutant/runner.rb
@@ -25,6 +25,10 @@ module Mutant
     private_class_method :run_mutation_analysis
 
     def self.run_driver(reporter, driver)
+      Signal.trap('INT') do
+        driver.stop
+      end
+
       loop do
         status = driver.wait_timeout(reporter.delay)
         break status.payload if status.done?

--- a/spec/support/xspec.rb
+++ b/spec/support/xspec.rb
@@ -138,7 +138,8 @@ module XSpec
           "#{message},
           observation:
           #{observation.inspect}
-          expectation: #{expectation.inspect}"
+          expectation:
+          #{expectation.inspect}"
         MESSAGE
       end
     end # Verifier


### PR DESCRIPTION
* Mutant will now gracefully exit on SIGINT, but still with urgency.
* All active worker threads and their child processes will get killed.
* Only currently finished mutations will be reported.
* Exit status will depend on the current results, if they are all green:
  you get an exist 0, otherwise nonzero.