### PR TITLE
Fix capture group mutations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+* [#1332](https://github.com/mbj/mutant/pull/1332)
+
+  Fix incomplete mutations for regexp capture groups. As an example, `/(\w\d)/` now gets mutated to `/(\W\d)/` and `/(\w\D)/` instead of just the former case.
+
+  Fix capture group -> passive group mutations which would not get properly generated in many cases. As an example, `/(\w\d)/` would get mutated to `/(?:\w)/` instead of `/(?:\w\d)/` like it will now.
+
 # v0.11.10 2022-05-02
 
 * [#1328](https://github.com/mbj/mutant/pull/1328)

--- a/lib/mutant/mutator/node/regexp/capture_group.rb
+++ b/lib/mutant/mutator/node/regexp/capture_group.rb
@@ -8,15 +8,13 @@ module Mutant
         class CaptureGroup < Node
           handle(:regexp_capture_group)
 
-          children :group
-
         private
 
           def dispatch
-            return unless group
+            return if children.empty?
 
-            emit(s(:regexp_passive_group, group))
-            emit_group_mutations
+            emit(s(:regexp_passive_group, *children))
+            children.each_index(&method(:mutate_child))
           end
         end # EndOfLineAnchor
       end # Regexp

--- a/meta/regexp/regexp_capture_group.rb
+++ b/meta/regexp/regexp_capture_group.rb
@@ -17,3 +17,14 @@ Mutant::Meta::Example.add :regexp_capture_group do
   mutation '/(foo)/'
   mutation '/(bar)/'
 end
+
+Mutant::Meta::Example.add :regexp_capture_group do
+  source '/(\w\d)/'
+
+  singleton_mutations
+  regexp_mutations
+
+  mutation '/(?:\w\d)/'
+  mutation '/(\W\d)/'
+  mutation '/(\w\D)/'
+end


### PR DESCRIPTION
- Fix incomplete mutations for regexp capture groups. As an example, `/(\w\d)/` now gets mutated to `/(\W\d)/` and `/(\w\D)/` instead of just the former case.
- Likewise, fix capture group -> passive group mutations which would not get properly generated in many cases. As an example, `/(\w\d)/` would get mutated to `/(?:\w)/` instead of `/(?:\w\d)/` like it will now.
- Closely related to #1328