### PR TITLE
Change Mutant::Config::DEFAULT to be well formed at all times

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# v0.11.14 2022-09-05
+
+* [#1353](https://github.com/mbj/mutant/pull/1353)
+
+  Fix to provide a well formed `Mutant::Config::DEFAULT` constant at all times.
+  Primarily useful for custom 3rd party integrations that use mutants API directly.
+
 # v0.11.14 2022-07-31
 
 * [#1348](https://github.com/mbj/mutant/pull/1348)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.11.14)
+    mutant (0.11.15)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
       regexp_parser (~> 2.3, >= 2.3.1)
@@ -52,7 +52,7 @@ GEM
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    sorbet-runtime (0.5.10206)
+    sorbet-runtime (0.5.10400)
     unicode-display_width (2.1.0)
     unparser (0.6.5)
       diff-lcs (~> 1.3)

--- a/lib/mutant.rb
+++ b/lib/mutant.rb
@@ -273,7 +273,7 @@ module Mutant
   # Reopen class to initialize constant to avoid dep circle
   class Config
     DEFAULT = new(
-      coverage_criteria:     Config::CoverageCriteria::EMPTY,
+      coverage_criteria:     Config::CoverageCriteria::DEFAULT,
       expression_parser:     Expression::Parser.new([
         Expression::Descendants,
         Expression::Method,

--- a/lib/mutant/cli/command/environment.rb
+++ b/lib/mutant/cli/command/environment.rb
@@ -19,7 +19,9 @@ module Mutant
 
         def initialize(attributes)
           super(attributes)
-          @config = Config::DEFAULT
+          @config = Config::DEFAULT.with(
+            coverage_criteria: Config::CoverageCriteria::EMPTY
+          )
         end
 
         def bootstrap
@@ -37,7 +39,7 @@ module Mutant
             )
           end
 
-          @config = Config.env.merge(file_config).merge(@config).expand_defaults
+          @config = Config.env.merge(file_config).merge(@config)
         end
 
         def parse_remaining_arguments(arguments)

--- a/lib/mutant/config.rb
+++ b/lib/mutant/config.rb
@@ -98,16 +98,6 @@ module Mutant
       end
     end
 
-    # Expand config with defaults
-    #
-    # @return [Config]
-    def expand_defaults
-      with(
-        coverage_criteria: CoverageCriteria::DEFAULT.merge(coverage_criteria),
-        jobs:              jobs || 1
-      )
-    end
-
     def self.load_contents(env, path)
       Transform::Named
         .new(

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.11.14'
+  VERSION = '0.11.15'
 end # Mutant

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -104,9 +104,7 @@ module SharedContext
     end
 
     let(:config) do
-      Mutant::Config::DEFAULT.with(
-        reporter: Mutant::Reporter::Null.new
-      ).expand_defaults
+      Mutant::Config::DEFAULT.with(reporter: Mutant::Reporter::Null.new)
     end
 
     let(:subject_a_context) do

--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Mutant::CLI do
     let(:events)                  { []                                        }
     let(:expected_zombie)         { false                                     }
     let(:kernel)                  { class_double(Kernel)                      }
-    let(:load_config_file_config) { Mutant::Config::DEFAULT                   }
     let(:stderr)                  { instance_double(IO, :stderr, tty?: false) }
     let(:stdout)                  { instance_double(IO, :stdout, tty?: false) }
     let(:timer)                   { instance_double(Mutant::Timer)            }
@@ -18,6 +17,12 @@ RSpec.describe Mutant::CLI do
         stderr: stderr,
         stdout: stdout,
         timer:  timer
+      )
+    end
+
+    let(:load_config_file_config) do
+      Mutant::Config::DEFAULT.with(
+        coverage_criteria: Mutant::Config::CoverageCriteria::EMPTY
       )
     end
 
@@ -548,7 +553,7 @@ RSpec.describe Mutant::CLI do
 
     shared_context 'environment' do
       let(:arguments)            { %w[run]                                              }
-      let(:bootstrap_config)     { env_config.merge(file_config).expand_defaults        }
+      let(:bootstrap_config)     { env_config.merge(file_config)                        }
       let(:bootstrap_result)     { right(env)                                           }
       let(:env_result)           { instance_double(Mutant::Result::Env, success?: true) }
       let(:expected_exit)        { true                                                 }
@@ -1154,7 +1159,7 @@ RSpec.describe Mutant::CLI do
           let(:file_config)      { Mutant::Config::DEFAULT }
 
           context 'without coverage criteria in env or file' do
-            let(:bootstrap_config) { Mutant::Config::DEFAULT.expand_defaults }
+            let(:bootstrap_config) { Mutant::Config::DEFAULT }
 
             include_examples 'CLI run'
           end
@@ -1168,7 +1173,7 @@ RSpec.describe Mutant::CLI do
               )
             end
 
-            let(:bootstrap_config) { file_config.expand_defaults }
+            let(:bootstrap_config) { file_config }
 
             include_examples 'CLI run'
           end

--- a/spec/unit/mutant/config_spec.rb
+++ b/spec/unit/mutant/config_spec.rb
@@ -1,40 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Mutant::Config do
-  describe '#expand_defaults' do
-    let(:config) do
-      described_class::DEFAULT.with(
-        coverage_criteria: described_class::CoverageCriteria::EMPTY.with(
-          test_result: false
-        )
-      )
-    end
-
-    def apply
-      config.expand_defaults
-    end
-
-    context 'on empty jobs' do
-      it 'expands empty jobs' do
-        expect(apply.jobs).to eql(1)
-      end
-    end
-
-    context 'on present jobs' do
-      let(:config) { super().with(jobs: 2) }
-
-      it 'doesn not expand jobs' do
-        expect(apply.jobs).to eql(2)
-      end
-    end
-
-    it 'expands merges coverage criteria with defaults' do
-      expect(apply.coverage_criteria).to eql(
-        described_class::CoverageCriteria::DEFAULT.with(test_result: false)
-      )
-    end
-  end
-
   describe '#merge' do
     def apply
       original.merge(other)

--- a/spec/unit/mutant/reporter/cli/printer/config_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/config_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Config do
       it_reports(<<~'REPORT')
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     null
-        Jobs:            1
+        Jobs:            auto
         Includes:        []
         Requires:        []
       REPORT
@@ -38,7 +38,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Config do
       it_reports(<<~'REPORT')
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     foo
-        Jobs:            1
+        Jobs:            auto
         Includes:        []
         Requires:        []
       REPORT
@@ -52,7 +52,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::Config do
       it_reports(<<~'REPORT')
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     null
-        Jobs:            1
+        Jobs:            auto
         Includes:        []
         Requires:        []
         MutationTimeout: 2.1

--- a/spec/unit/mutant/reporter/cli/printer/env_progress_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/env_progress_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Mutant environment:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     null
-        Jobs:            1
+        Jobs:            auto
         Includes:        []
         Requires:        []
         Subjects:        1
@@ -38,7 +38,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Mutant environment:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     null
-        Jobs:            1
+        Jobs:            auto
         Includes:        []
         Requires:        []
         Subjects:        1
@@ -65,7 +65,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvProgress do
         Mutant environment:
         Matcher:         #<Mutant::Matcher::Config empty>
         Integration:     null
-        Jobs:            1
+        Jobs:            auto
         Includes:        []
         Requires:        []
         Subjects:        1

--- a/spec/unit/mutant/reporter/cli/printer/env_result_spec.rb
+++ b/spec/unit/mutant/reporter/cli/printer/env_result_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Mutant::Reporter::CLI::Printer::EnvResult do
       Mutant environment:
       Matcher:         #<Mutant::Matcher::Config empty>
       Integration:     null
-      Jobs:            1
+      Jobs:            auto
       Includes:        []
       Requires:        []
       Subjects:        1

--- a/spec/unit/mutant/reporter/cli_spec.rb
+++ b/spec/unit/mutant/reporter/cli_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Mutant::Reporter::CLI do
       Mutant environment:
       Matcher:         #<Mutant::Matcher::Config empty>
       Integration:     null
-      Jobs:            1
+      Jobs:            auto
       Includes:        []
       Requires:        []
       Subjects:        1
@@ -84,7 +84,7 @@ RSpec.describe Mutant::Reporter::CLI do
       Mutant environment:
       Matcher:         #<Mutant::Matcher::Config empty>
       Integration:     null
-      Jobs:            1
+      Jobs:            auto
       Includes:        []
       Requires:        []
       Subjects:        1


### PR DESCRIPTION
* 3rd party integrations should get good coverage criteria by default
  rather than the empty empty monoid.
* Overall this highlights that CLI parsing should be done outside of IO,
  but thats an issue to solve in later iterations.