### PR TITLE
Change to more efficient worker termination

### DIFF
--- a/lib/mutant/parallel/driver.rb
+++ b/lib/mutant/parallel/driver.rb
@@ -49,6 +49,7 @@ module Mutant
       def finalize(status)
         status.tap do
           if status.done?
+            workers.each(&:signal)
             workers.each(&:join)
             threads.each(&:join)
           end

--- a/lib/mutant/parallel/worker.rb
+++ b/lib/mutant/parallel/worker.rb
@@ -77,8 +77,12 @@ module Mutant
         self
       end
 
-      def join
+      def signal
         process.kill('TERM', pid)
+        self
+      end
+
+      def join
         process.wait(pid)
         self
       end

--- a/spec/unit/mutant/parallel/driver_spec.rb
+++ b/spec/unit/mutant/parallel/driver_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe Mutant::Parallel::Driver, mutant_expression: 'Mutant::Parallel::D
             *super(),
             {
               receiver: worker_a,
+              selector: :signal
+            },
+            {
+              receiver: worker_b,
+              selector: :signal
+            },
+            {
+              receiver: worker_a,
               selector: :join
             },
             {

--- a/spec/unit/mutant/parallel/worker_spec.rb
+++ b/spec/unit/mutant/parallel/worker_spec.rb
@@ -207,13 +207,38 @@ RSpec.describe Mutant::Parallel::Worker do
       [
         {
           receiver:  world.process,
-          selector:  :kill,
-          arguments: ['TERM', pid]
-        },
-        {
-          receiver:  world.process,
           selector:  :wait,
           arguments: [pid]
+        }
+      ]
+    end
+
+    it 'terminates and waits for process' do
+      verify_events { expect(apply).to be(object) }
+    end
+  end
+
+  describe '#signal' do
+    let(:object) do
+      described_class.new(
+        connection: connection,
+        index:      index,
+        pid:        pid,
+        process:    world.process,
+        **shared
+      )
+    end
+
+    def apply
+      object.signal
+    end
+
+    let(:raw_expectations) do
+      [
+        {
+          receiver:  world.process,
+          selector:  :kill,
+          arguments: ['TERM', pid]
         }
       ]
     end


### PR DESCRIPTION
* Before: Mutant would terminate all worker processes in sequence, while waiting for each pid to terminate separtae. This creates way more context switches than needed and resulted in a serial bottleneck.
* Now mutant signals all worker processes than collects the statuses in a secondary loop.
* Reducing this serial dependency improves mutant exit performance by several seconds on a high core cound machine, and is also measurable on more regular machines.


```
main: time bundle exec mutant run --zombie --since HEAD # 0 mutations selected.

5.69s user 4.35s system 99% cpu 10.061 total

this-branch: bundle exec mutant run --zombie --since HEAD # 0 mutations seleced.

6.23s user 50.38s system 1189% cpu 4.760 total 
```

Note for this benchmarks mutant needs to dynamically self vendor first, `--zombie` is quite expensive and noone but mutant developers should ever use it.