### PR TITLE
Demonstrate strange parsing behavior for repository-based licenses

### DIFF
--- a/spec/unit/mutant/license/opensource/repository_spec.rb
+++ b/spec/unit/mutant/license/opensource/repository_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Mutant::License::Subscription::Opensource::Repository do
+  describe '.parse' do
+    it 'can parse SSH remotes' do
+      expect(described_class.parse('git@github.com:mbj/mutant.git')).to eql(
+        described_class.new('github.com', 'mbj/mutant.git')
+      )
+    end
+    # or it should maybe more likely be:
+    it 'can parse SSH remotes' do
+      expect(described_class.parse('git@github.com:mbj/mutant.git')).to eql(
+        described_class.new('github.com', 'mbj/mutant')
+      )
+    end
+
+    it 'can parse https remotes' do
+      expect(described_class.parse('https://github.example.com/org/repo')).to eql(
+        described_class.new('github.example.com', 'org/repo')
+      )
+    end
+
+    it 'can parse https remotes with a wildcard' do
+      expect(described_class.parse('https://github.com/*')).to eql(
+        described_class.new('github.com', '/*')
+      )
+    end
+  end
+end


### PR DESCRIPTION
- Added some failing tests to help debug why I am getting unexpected licensing behavior.

I don't have time to fix this but I thought it might save you some debugging time to see the strange behavior I noticed when manually parsing remotes, @mbj.