### PR TITLE
Fix else/if branch deletion on ternary unparse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
+        include:
+        - os: macos-latest
+          ruby: ruby-3.2
+        - os: macos-latest
+          ruby: ruby-3.1
+        - os: macos-latest
+          ruby: ruby-3.0
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -34,7 +41,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
+        include:
+        - os: macos-latest
+          ruby: ruby-3.2
+        - os: macos-latest
+          ruby: ruby-3.1
+        - os: macos-latest
+          ruby: ruby-3.0
     steps:
     - uses: actions/checkout@v3
       with:
@@ -52,7 +66,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
+        include:
+        - os: macos-latest
+          ruby: ruby-3.2
+        - os: macos-latest
+          ruby: ruby-3.1
+        - os: macos-latest
+          ruby: ruby-3.0
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -72,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -88,7 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -104,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -120,7 +141,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1.3, ruby-3.2]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1.3, ruby-3.2]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1.3, ruby-3.2]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1.3, ruby-3.2]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1.3, ruby-3.2]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1.3, ruby-3.2]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1.3, ruby-3.2]
+        ruby: [ruby-2.7, ruby-3.0, ruby-3.1.2, ruby-3.1, ruby-3.2]
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# v0.11.19 2023-05-6
+
+* [#1376](https://github.com/mbj/mutant/pull/1376)
+
+  Fix crash on code that must have been a ternary on original source.
+
 # v0.11.18 2023-01-08
 
 * [#1367](https://github.com/mbj/mutant/pull/1367)

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@
 
   Fix crash on code that must have been a ternary on original source.
 
+* [#1373](https://github.com/mbj/mutant/pull/1373)
+
+  Change to more performant rspec integration. Significant rspec runner
+  speed improvement on projets with a very large number of tests.
+
 # v0.11.18 2023-01-08
 
 * [#1367](https://github.com/mbj/mutant/pull/1367)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.11.18)
+    mutant (0.11.19)
       diff-lcs (~> 1.3)
       parser (~> 3.2.2)
       regexp_parser (~> 2.6.1)

--- a/lib/mutant/mutator/node/if.rb
+++ b/lib/mutant/mutator/node/if.rb
@@ -5,6 +5,7 @@ module Mutant
     class Node
       # Mutator for if nodes
       class If < self
+        FLOW_MODIFIER = %i[return next break].to_set.freeze
 
         handle(:if)
 
@@ -41,6 +42,14 @@ module Mutant
           emit(else_branch)
           emit_else_branch_mutations
           emit_type(condition, nil, else_branch)
+        end
+
+        def emit_type(_condition, if_branch, else_branch)
+          super unless ternary? && (if_branch.nil? || else_branch.nil?)
+        end
+
+        def ternary?
+          parent && FLOW_MODIFIER.include?(parent.node.type)
         end
 
       end # If

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.11.18'
+  VERSION = '0.11.19'
 end # Mutant

--- a/meta/if.rb
+++ b/meta/if.rb
@@ -70,3 +70,19 @@ Mutant::Meta::Example.add :if do
   mutation 'true if /nomatch\A/'
   mutation 'true'
 end
+
+Mutant::Meta::Example.add :if do
+  source <<~RUBY
+    return true ? true : false
+  RUBY
+
+  singleton_mutations
+  mutation 'return false'
+  mutation 'return !true ? true : false'
+  mutation 'return true'
+  mutation 'return false ? true : false'
+  mutation 'return true ? false : false'
+  mutation 'return true ? true : true'
+  mutation 'return nil'
+  mutation 'if true; true; else; false; end'
+end

--- a/test_app/Gemfile.minitest.lock
+++ b/test_app/Gemfile.minitest.lock
@@ -1,15 +1,15 @@
 PATH
   remote: ..
   specs:
-    mutant (0.11.18)
+    mutant (0.11.19)
       diff-lcs (~> 1.3)
       parser (~> 3.2.2)
       regexp_parser (~> 2.6.1)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.6.7)
-    mutant-minitest (0.11.18)
+    mutant-minitest (0.11.19)
       minitest (~> 5.11)
-      mutant (= 0.11.18)
+      mutant (= 0.11.19)
 
 GEM
   remote: https://oss:Px2ENN7S91OmWaD5G7MIQJi1dmtmYrEh@gem.mutant.dev/

--- a/test_app/Gemfile.rspec3.8.lock
+++ b/test_app/Gemfile.rspec3.8.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.11.18)
+    mutant (0.11.19)
       diff-lcs (~> 1.3)
       parser (~> 3.2.2)
       regexp_parser (~> 2.6.1)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.6.7)
-    mutant-rspec (0.11.18)
-      mutant (= 0.11.18)
+    mutant-rspec (0.11.19)
+      mutant (= 0.11.19)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM


### PR DESCRIPTION
* If its guaranteed the original code must have been a ternary, and thus will also be unparsed as a ternary: Mutant cannot delete the if or else branches.
* If its not guaranteed the original code was a ternary mutant can freely produce AST without if or else branch and unparser will know on how to generate equivalent AST.

Fixes the crashing case from: https://github.com/mbj/mutant/pull/1374 but with a smaller more localized reproduction.