### PR TITLE
Change hooks to use kwargs

### DIFF
--- a/lib/mutant/bootstrap.rb
+++ b/lib/mutant/bootstrap.rb
@@ -88,7 +88,7 @@ module Mutant
         config, hooks, world = env.config, env.hooks, env.world
 
         env.record(:hooks_env_infection_pre) do
-          hooks.run(:env_infection_pre, env)
+          hooks.run(:env_infection_pre, env: env)
         end
 
         env.record(:require_target) do
@@ -101,7 +101,7 @@ module Mutant
         end
 
         env.record(:hooks_env_infection_post) do
-          hooks.run(:env_infection_post, env)
+          hooks.run(:env_infection_post, env: env)
         end
       end
     end

--- a/lib/mutant/env.rb
+++ b/lib/mutant/env.rb
@@ -155,9 +155,9 @@ module Mutant
 
     def run_mutation_tests(mutation, tests)
       config.isolation.call(config.mutation.timeout) do
-        hooks.run(:mutation_insert_pre, mutation)
+        hooks.run(:mutation_insert_pre, mutation: mutation)
         result = mutation.insert(world.kernel)
-        hooks.run(:mutation_insert_post, mutation)
+        hooks.run(:mutation_insert_post, mutation: mutation)
 
         result.either(
           ->(_) { Result::Test::VoidValue.instance },

--- a/lib/mutant/hooks.rb
+++ b/lib/mutant/hooks.rb
@@ -32,10 +32,10 @@ module Mutant
       )
     end
 
-    def run(name, payload)
+    def run(name, **payload)
       Hooks.assert_name(name)
 
-      map.fetch(name).each { |block| block.call(payload) }
+      map.fetch(name).each { |block| block.call(**payload) }
 
       self
     end

--- a/spec/unit/mutant/bootstrap_spec.rb
+++ b/spec/unit/mutant/bootstrap_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Mutant::Bootstrap do
       {
         receiver:  hooks,
         selector:  :run,
-        arguments: [:env_infection_pre, env_initial]
+        arguments: [:env_infection_pre, { env: env_initial }]
       },
       {
         receiver:  world,
@@ -147,7 +147,7 @@ RSpec.describe Mutant::Bootstrap do
       {
         receiver:  hooks,
         selector:  :run,
-        arguments: [:env_infection_post, env_initial]
+        arguments: [:env_infection_post, { env: env_initial }]
       },
       {
         receiver:  world,

--- a/spec/unit/mutant/env_spec.rb
+++ b/spec/unit/mutant/env_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe Mutant::Env do
         apply
 
         expect(isolation).to have_received(:call).ordered.with(config.mutation.timeout)
-        expect(hooks).to have_received(:run).ordered.with(:mutation_insert_pre, mutation)
+        expect(hooks).to have_received(:run).ordered.with(:mutation_insert_pre, mutation: mutation)
         expect(mutation).to have_received(:insert).ordered.with(world.kernel)
-        expect(hooks).to have_received(:run).ordered.with(:mutation_insert_post, mutation)
+        expect(hooks).to have_received(:run).ordered.with(:mutation_insert_post, mutation: mutation)
         expect(integration).to have_received(:call).ordered.with([test_a, test_b])
       end
 

--- a/spec/unit/mutant/hooks_spec.rb
+++ b/spec/unit/mutant/hooks_spec.rb
@@ -34,8 +34,8 @@ end
 RSpec.describe Mutant::Hooks do
   let(:source) do
     <<~'RUBY'
-      hooks.register(:mutation_insert_pre) do |param|
-        param << [__FILE__, __LINE__]
+      hooks.register(:mutation_insert_pre) do |mutation:|
+        mutation << [__FILE__, __LINE__]
       end
     RUBY
   end
@@ -90,7 +90,7 @@ RSpec.describe Mutant::Hooks do
     end
 
     it 'returns hooks equivalent to merged registration sequence' do
-      apply.run(:mutation_insert_pre, nil)
+      apply.run(:mutation_insert_pre, foo: nil)
 
       expect(yields).to eql(%i[block_a block_b])
     end
@@ -107,7 +107,7 @@ RSpec.describe Mutant::Hooks do
     end
 
     def apply
-      subject.run(name, payload)
+      subject.run(name, foo: payload)
     end
 
     include_context 'unknown hook name'
@@ -135,7 +135,7 @@ RSpec.describe Mutant::Hooks do
           expect { apply }
             .to change(yields, :to_a)
             .from([])
-            .to([payload, payload])
+            .to([{ foo: payload }, { foo: payload }])
         end
       end
     end
@@ -157,7 +157,7 @@ RSpec.describe Mutant::Hooks do
     it 'allows to capture hooks' do
       payload = []
 
-      apply.run(:mutation_insert_pre, payload)
+      apply.run(:mutation_insert_pre, mutation: payload)
 
       expect(payload).to eql([['example.rb', 2]])
     end
@@ -185,7 +185,7 @@ RSpec.describe Mutant::Hooks do
     it 'loads hooks in sequence' do
       yields = []
 
-      apply.run(:mutation_insert_pre, yields)
+      apply.run(:mutation_insert_pre, mutation: yields)
 
       expect(yields).to eql(
         [
@@ -212,9 +212,9 @@ RSpec.describe Mutant::Hooks::Builder do
       let(:name) { :mutation_insert_pre }
 
       it 'registers hook' do
-        apply.to_hooks.run(name, nil)
+        apply.to_hooks.run(name, foo: nil)
 
-        expect(yields).to eql([nil])
+        expect(yields).to eql([{ foo: nil }])
       end
 
       it 'returns self' do


### PR DESCRIPTION
* Hooks where so far not yet documented so this is not a breaking change of documented public API.
* But it allows much better evolution for adding more context to the hooks in the future.