### PR TITLE
Remove unused let & fix malformed test

### DIFF
--- a/spec/unit/mutant/ast/pattern/source_spec.rb
+++ b/spec/unit/mutant/ast/pattern/source_spec.rb
@@ -29,12 +29,11 @@ RSpec.describe Mutant::AST::Pattern::Source do
     end
 
     context 'on non unix newline' do
-      let(:input) { "a\r\nb" }
-
+      let(:string) { "a\r\nb" }
       let(:line_index) { 0 }
 
       it 'considers the \r as part of the previous line' do
-        expect(apply).to eql('a')
+        expect(apply).to eql("a\r")
       end
     end
   end

--- a/spec/unit/mutant/matcher/method/singleton_spec.rb
+++ b/spec/unit/mutant/matcher/method/singleton_spec.rb
@@ -53,8 +53,6 @@ RSpec.describe Mutant::Matcher::Method::Singleton, '#call' do
     it_should_behave_like 'a method matcher' do
       %i[public protected private].each do |visibility|
         context 'with %s visibility' % visibility do
-          let(:expected_visibility) { visibility }
-
           before do
             scope.singleton_class.__send__(visibility, method_name)
           end


### PR DESCRIPTION
- Removes an unused let that does not seem to serve an obvious purpose.
- Fixes a test where an unused let lead to a specified case not being tested.
- Mainly using `mutant` as a canary for an [`rspectre`](https://github.com/dgollahon/rspectre) release.