### PR TITLE
Add support for forwarded rest arguments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Add support for forwarded rest arguments `def foo(*); bar(*); end` which previously caused `mutant` to crash.
+
+  [#TODO](https://github.com/mbj/mutant/pull/TODO)
+
 # v0.11.22 2023-07-16
 
 * Introduce mutation operators config 'light' and 'full'. Mutant will default to

--- a/lib/mutant/ast/structure.rb
+++ b/lib/mutant/ast/structure.rb
@@ -392,6 +392,11 @@ module Mutant
           variable: nil
         ),
         Node.new(
+          type:     :forwarded_restarg,
+          fixed:    EMPTY_ARRAY,
+          variable: nil
+        ),
+        Node.new(
           type:     :for,
           fixed:    Node.fixed(
             [

--- a/lib/mutant/mutator/node/arguments.rb
+++ b/lib/mutant/mutator/node/arguments.rb
@@ -25,7 +25,7 @@ module Mutant
           children.each_with_index do |removed, index|
             new_arguments = children.dup
             new_arguments.delete_at(index)
-            unless n_forward_arg?(removed) || removed_block_arg?(new_arguments) || only_mlhs?(new_arguments)
+            unless forward_type?(removed) || removed_block_arg?(new_arguments) || only_mlhs?(new_arguments)
               emit_type(*new_arguments)
             end
           end
@@ -36,7 +36,12 @@ module Mutant
         end
 
         def forward_arg?
-          children.last && n_forward_arg?(children.last)
+          children.any?(&method(:forward_type?))
+        end
+
+        def forward_type?(node)
+          n_forward_arg?(node) ||
+              ((n_restarg?(node) || n_kwrestarg?(node)) && node.children.empty?)
         end
 
         def removed_block_arg?(new_arguments)

--- a/lib/mutant/mutator/node/send.rb
+++ b/lib/mutant/mutator/node/send.rb
@@ -223,7 +223,7 @@ module Mutant
 
           argument = Mutant::Util.one(arguments)
 
-          return if n_kwargs?(argument) || n_forwarded_args?(argument)
+          return if n_kwargs?(argument) || n_forwarded_args?(argument) || n_forwarded_restarg?(argument)
 
           emit_propagation(argument)
         end

--- a/meta/def.rb
+++ b/meta/def.rb
@@ -195,6 +195,40 @@ Mutant::Meta::Example.add :def do
   mutation 'def foo(...); super; end'
 end
 
+if RUBY_VERSION >= '3.2'
+  Mutant::Meta::Example.add :def do
+    source 'def foo(*); bar(*); end'
+
+    mutation 'def foo(*); raise; end'
+    mutation 'def foo(*); super; end'
+    mutation 'def foo(*); end'
+    mutation 'def foo(*); nil; end'
+    mutation 'def foo(*); bar; end'
+  end
+
+  Mutant::Meta::Example.add :def do
+    source 'def foo(**); bar(**); end'
+
+    mutation 'def foo(**); raise; end'
+    mutation 'def foo(**); super; end'
+    mutation 'def foo(**); end'
+    mutation 'def foo(**); nil; end'
+    mutation 'def foo(**); bar; end'
+  end
+end
+
+if RUBY_VERSION >= '3.1'
+  Mutant::Meta::Example.add :def do
+    source 'def foo(&); bar(&); end'
+
+    mutation 'def foo(&); raise; end'
+    mutation 'def foo(&); super; end'
+    mutation 'def foo(&); end'
+    mutation 'def foo(&); nil; end'
+    mutation 'def foo(&); bar; end'
+  end
+end
+
 Mutant::Meta::Example.add :def do
   source 'def foo(a, ...); end'
 


### PR DESCRIPTION
- Allows `def foo(*); bar(*); end` to work without crashing `mutant`.