### PR TITLE
Fix zombifier on memoized methods

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# v0.12.5 unreleased
+
+* [#1458](https://github.com/mbj/mutant/pull/1458)
+
+  Fix zombifier on memoized methods (only relevant for mutant developers).
+
 # v0.12.4 2024-06-30
 
 * [#1455](https://github.com/mbj/mutant/pull/1455)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,16 @@
 # v0.12.4 2024-06-30
 
-* [#1455](https://github.com/mbj/mutant/pull/1454)
+* [#1455](https://github.com/mbj/mutant/pull/1455)
 
   Fix parsing of empty rspec descriptions
 
 # v0.12.3 2024-06-10
 
-* [#1452](https://github.com/mbj/mutant/pull/1451)
+* [#1453](https://github.com/mbj/mutant/pull/1453)
 
   Remove support for EOL Ruby-3.0.
+
+* [#1450](https://github.com/mbj/mutant/pull/1450)
   Remove another invalid mutation to super().
 
 # v0.12.2 2024-06-09

--- a/lib/mutant/matcher/method/instance.rb
+++ b/lib/mutant/matcher/method/instance.rb
@@ -30,8 +30,12 @@ module Mutant
         end
         # rubocop:enable Metrics/MethodLength
 
+        TARGET_MEMOIZER = ::Mutant::Adamantium
+
+        private_constant(*constants(false))
+
         def self.memoized_method?(scope, method_name)
-          scope.raw < Adamantium && scope.raw.memoized?(method_name)
+          scope.raw < TARGET_MEMOIZER && scope.raw.memoized?(method_name)
         end
         private_class_method :memoized_method?
 


### PR DESCRIPTION
* When mutant runs zombified (for self tests) the `Zombie::Mutant` namespace tests the `Mutant` namespace.
* So when the `Zombie::Mutant` runs it has to be able to reference the "regular" `Adamantium` not the zombified when testing if a memoized method has to be unwound.