### PR TITLE
Upgrade regexp parser dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# v0.13.1 2025-03-23
+
+  Add new `mutant test` primary subcommand. This subcommand allows
+  to run rspec (or minitest) tests via mutants *parallel* test runner.
+
+  Standard precautions to correctly synchronize or isolate global resources
+  (fileystems / database) apply.
+
 # v0.13.0 2025-03-23
 
   Significant unparser upgrade. Mutant now:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# v0.13.0 unreleased
+# v0.13.0 2025-03-23
 
   Significant unparser upgrade. Mutant now:
 
@@ -21,7 +21,7 @@
     implicit self receivers in the past. But this was not intended by these mutations, at least not
     without explicitly changing the reads to send nodes explicitly.
 
-# v0.12.5 unreleased
+# v0.12.5 2024-06-30
 
 * [#1458](https://github.com/mbj/mutant/pull/1458)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     mutant (0.13.0)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
-      regexp_parser (~> 2.9.0)
+      regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
 
@@ -22,7 +22,7 @@ GEM
       racc
     racc (1.8.1)
     rainbow (3.1.1)
-    regexp_parser (2.9.3)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mutant (0.13.0)
+    mutant (0.13.1)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
       regexp_parser (~> 2.10)

--- a/lib/mutant/cli/command/environment/test.rb
+++ b/lib/mutant/cli/command/environment/test.rb
@@ -63,6 +63,12 @@ module Mutant
                 Either::Left.new('Test failures, exiting nonzero!')
               end
             end
+
+            # Alias to root mount
+            class Root < self
+              NAME        = 'test'
+              SUBCOMMANDS = EMPTY_ARRAY
+            end
           end
 
           SUBCOMMANDS = [List, Run].freeze

--- a/lib/mutant/cli/command/root.rb
+++ b/lib/mutant/cli/command/root.rb
@@ -10,7 +10,7 @@ module Mutant
       class Root < self
         NAME              = 'mutant'
         SHORT_DESCRIPTION = 'mutation testing engine main command'
-        SUBCOMMANDS       = [Environment::Run, Environment, Util].freeze
+        SUBCOMMANDS       = [Environment::Run, Environment::Test::Run::Root, Environment, Util].freeze
       end # Root
     end # Command
   end # CLI

--- a/lib/mutant/version.rb
+++ b/lib/mutant/version.rb
@@ -2,5 +2,5 @@
 
 module Mutant
   # Current mutant version
-  VERSION = '0.13.0'
+  VERSION = '0.13.1'
 end # Mutant

--- a/mutant.gemspec
+++ b/mutant.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('diff-lcs',       '~> 1.3')
   gem.add_dependency('parser',         '~> 3.3.0')
-  gem.add_dependency('regexp_parser',  '~> 2.9.0')
+  gem.add_dependency('regexp_parser',  '~> 2.10')
   gem.add_dependency('sorbet-runtime', '~> 0.5.0')
   gem.add_dependency('unparser',       '~> 0.7.0')
 

--- a/spec/shared/framework_integration_behavior.rb
+++ b/spec/shared/framework_integration_behavior.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples_for 'framework integration' do
   around do |example|
     Bundler.with_unbundled_env do
       Dir.chdir(TestApp.root) do
-        Kernel.system(*p('bundle', 'install', '--gemfile', gemfile)) || fail('Bundle install failed!')
+        Kernel.system('bundle', 'install', '--gemfile', gemfile) || fail('Bundle install failed!')
         example.run
       end
     end

--- a/spec/unit/mutant/cli_spec.rb
+++ b/spec/unit/mutant/cli_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Mutant::CLI do
     # rubocop:disable Metrics/MethodLength
     def self.main_body
       <<~MESSAGE.strip
-        usage: mutant <run|environment|util> [options]
+        usage: mutant <run|test|environment|util> [options]
 
         Summary: mutation testing engine main command
 
@@ -120,6 +120,7 @@ RSpec.describe Mutant::CLI do
         Available subcommands:
 
         run         - Run code analysis
+        test        - Run tests
         environment - Environment subcommands
         util        - Utility subcommands
       MESSAGE

--- a/test_app/Gemfile.minitest.lock
+++ b/test_app/Gemfile.minitest.lock
@@ -1,15 +1,15 @@
 PATH
   remote: ..
   specs:
-    mutant (0.13.0)
+    mutant (0.13.1)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
       regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
-    mutant-minitest (0.13.0)
+    mutant-minitest (0.13.1)
       minitest (~> 5.11)
-      mutant (= 0.13.0)
+      mutant (= 0.13.1)
       mutex_m (~> 0.2)
 
 GEM

--- a/test_app/Gemfile.minitest.lock
+++ b/test_app/Gemfile.minitest.lock
@@ -4,7 +4,7 @@ PATH
     mutant (0.13.0)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
-      regexp_parser (~> 2.9.0)
+      regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
     mutant-minitest (0.13.0)
@@ -23,7 +23,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
-    regexp_parser (2.9.3)
+    regexp_parser (2.10.0)
     sorbet-runtime (0.5.11953)
     unparser (0.7.0)
       diff-lcs (~> 1.6)

--- a/test_app/Gemfile.rspec3.10.lock
+++ b/test_app/Gemfile.rspec3.10.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.13.0)
+    mutant (0.13.1)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
       regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
-    mutant-rspec (0.13.0)
-      mutant (= 0.13.0)
+    mutant-rspec (0.13.1)
+      mutant (= 0.13.1)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM

--- a/test_app/Gemfile.rspec3.10.lock
+++ b/test_app/Gemfile.rspec3.10.lock
@@ -4,7 +4,7 @@ PATH
     mutant (0.13.0)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
-      regexp_parser (~> 2.9.0)
+      regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
     mutant-rspec (0.13.0)
@@ -26,7 +26,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
-    regexp_parser (2.9.3)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -57,4 +57,4 @@ DEPENDENCIES
   rspec-core (~> 3.10)
 
 BUNDLED WITH
-   2.5.22
+   2.6.2

--- a/test_app/Gemfile.rspec3.11.lock
+++ b/test_app/Gemfile.rspec3.11.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.13.0)
+    mutant (0.13.1)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
       regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
-    mutant-rspec (0.13.0)
-      mutant (= 0.13.0)
+    mutant-rspec (0.13.1)
+      mutant (= 0.13.1)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM

--- a/test_app/Gemfile.rspec3.11.lock
+++ b/test_app/Gemfile.rspec3.11.lock
@@ -4,7 +4,7 @@ PATH
     mutant (0.13.0)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
-      regexp_parser (~> 2.9.0)
+      regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
     mutant-rspec (0.13.0)
@@ -26,7 +26,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
-    regexp_parser (2.9.3)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -57,4 +57,4 @@ DEPENDENCIES
   rspec-core (~> 3.12)
 
 BUNDLED WITH
-   2.5.22
+   2.6.2

--- a/test_app/Gemfile.rspec3.12.lock
+++ b/test_app/Gemfile.rspec3.12.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.13.0)
+    mutant (0.13.1)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
       regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
-    mutant-rspec (0.13.0)
-      mutant (= 0.13.0)
+    mutant-rspec (0.13.1)
+      mutant (= 0.13.1)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM
@@ -57,4 +57,4 @@ DEPENDENCIES
   rspec-core (~> 3.9)
 
 BUNDLED WITH
-   2.5.22
+   2.6.2

--- a/test_app/Gemfile.rspec3.12.lock
+++ b/test_app/Gemfile.rspec3.12.lock
@@ -4,7 +4,7 @@ PATH
     mutant (0.13.0)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
-      regexp_parser (~> 2.9.0)
+      regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
     mutant-rspec (0.13.0)
@@ -26,7 +26,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
-    regexp_parser (2.9.0)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)

--- a/test_app/Gemfile.rspec3.13.lock
+++ b/test_app/Gemfile.rspec3.13.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.13.0)
+    mutant (0.13.1)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
       regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
-    mutant-rspec (0.13.0)
-      mutant (= 0.13.0)
+    mutant-rspec (0.13.1)
+      mutant (= 0.13.1)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM

--- a/test_app/Gemfile.rspec3.13.lock
+++ b/test_app/Gemfile.rspec3.13.lock
@@ -4,7 +4,7 @@ PATH
     mutant (0.13.0)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
-      regexp_parser (~> 2.9.0)
+      regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
     mutant-rspec (0.13.0)
@@ -26,7 +26,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
-    regexp_parser (2.9.0)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -57,4 +57,4 @@ DEPENDENCIES
   rspec-core (~> 3.13)
 
 BUNDLED WITH
-   2.5.22
+   2.6.2

--- a/test_app/Gemfile.rspec3.8.lock
+++ b/test_app/Gemfile.rspec3.8.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.13.0)
+    mutant (0.13.1)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
       regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
-    mutant-rspec (0.13.0)
-      mutant (= 0.13.0)
+    mutant-rspec (0.13.1)
+      mutant (= 0.13.1)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM

--- a/test_app/Gemfile.rspec3.8.lock
+++ b/test_app/Gemfile.rspec3.8.lock
@@ -4,7 +4,7 @@ PATH
     mutant (0.13.0)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
-      regexp_parser (~> 2.9.0)
+      regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
     mutant-rspec (0.13.0)
@@ -26,7 +26,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
-    regexp_parser (2.9.3)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -57,4 +57,4 @@ DEPENDENCIES
   rspec-core (~> 3.8)
 
 BUNDLED WITH
-   2.5.22
+   2.6.2

--- a/test_app/Gemfile.rspec3.9.lock
+++ b/test_app/Gemfile.rspec3.9.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ..
   specs:
-    mutant (0.13.0)
+    mutant (0.13.1)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
       regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
-    mutant-rspec (0.13.0)
-      mutant (= 0.13.0)
+    mutant-rspec (0.13.1)
+      mutant (= 0.13.1)
       rspec-core (>= 3.8.0, < 4.0.0)
 
 GEM

--- a/test_app/Gemfile.rspec3.9.lock
+++ b/test_app/Gemfile.rspec3.9.lock
@@ -4,7 +4,7 @@ PATH
     mutant (0.13.0)
       diff-lcs (~> 1.3)
       parser (~> 3.3.0)
-      regexp_parser (~> 2.9.0)
+      regexp_parser (~> 2.10)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.7.0)
     mutant-rspec (0.13.0)
@@ -26,7 +26,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
-    regexp_parser (2.9.3)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -57,4 +57,4 @@ DEPENDENCIES
   rspec-core (~> 3.9)
 
 BUNDLED WITH
-   2.5.22
+   2.6.2


### PR DESCRIPTION
* Mutant used to have a more "invasive" regexp-parser integration so we had to be sure there are no "new" AST nodes added between releases.
* This is gone for a longer time, so we can depend on less specific `regexp-parser` dependencies^