### PR TITLE
Remove uncanonical mutation from `@foo` to `foo`

### DIFF
--- a/ruby/lib/mutant/mutator/node/named_value/access.rb
+++ b/ruby/lib/mutant/mutator/node/named_value/access.rb
@@ -8,37 +8,13 @@ module Mutant
         # Mutation emitter to handle named value access nodes
         class Access < Node
 
-          handle(:gvar, :cvar, :lvar, :self)
+          handle(:gvar, :cvar, :ivar, :lvar, :self)
 
         private
 
           def dispatch
             emit_singletons
           end
-
-          # Named value access emitter for instance variables
-          class Ivar < Access
-            NAME_RANGE = (1..-1)
-
-            handle(:ivar)
-
-            children :name
-
-          private
-
-            def dispatch
-              emit_attribute_read
-              super
-            end
-
-            def emit_attribute_read
-              emit(s(:send, nil, attribute_name))
-            end
-
-            def attribute_name
-              name.slice(NAME_RANGE).to_sym
-            end
-          end # Ivar
 
         end # Access
       end # NamedValue

--- a/ruby/meta/ivar.rb
+++ b/ruby/meta/ivar.rb
@@ -4,5 +4,4 @@ Mutant::Meta::Example.add :ivar do
   source '@foo'
 
   singleton_mutations
-  mutation 'foo'
 end

--- a/ruby/meta/op_assgn.rb
+++ b/ruby/meta/op_assgn.rb
@@ -7,7 +7,6 @@ Mutant::Meta::Example.add :op_asgn, :send do
   mutation '@a.b += 0'
   mutation '@a.b += 2'
   mutation '@a.b += nil'
-  mutation 'a.b += 1'
   mutation 'self.b += 1'
 end
 


### PR DESCRIPTION
This mutation is uncanonical as it mutates a simple primitive to a complex primitive. A method call has a much wider semantic surface than an instance variable read.