### PR TITLE
Add visual progress bar for TTY output

### DIFF
--- a/ruby/lib/mutant.rb
+++ b/ruby/lib/mutant.rb
@@ -237,6 +237,7 @@ module Mutant
     require 'mutant/reporter/null'
     require 'mutant/reporter/sequence'
     require 'mutant/reporter/cli'
+    require 'mutant/reporter/cli/progress_bar'
     require 'mutant/reporter/cli/printer'
     require 'mutant/reporter/cli/printer/config'
     require 'mutant/reporter/cli/printer/coverage_result'

--- a/ruby/lib/mutant/reporter/cli/format.rb
+++ b/ruby/lib/mutant/reporter/cli/format.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'io/console'
+
 module Mutant
   class Reporter
     class CLI
@@ -7,7 +9,20 @@ module Mutant
       #
       # rubocop:disable Style/FormatString
       class Format
-        include AbstractType, Anima.new(:tty)
+        include AbstractType, Anima.new(:tty, :output_io)
+
+        DEFAULT_TERMINAL_WIDTH = 80
+
+        # Dynamic terminal width - queries current size on each call
+        #
+        # @return [Integer]
+        def terminal_width
+          return DEFAULT_TERMINAL_WIDTH unless tty && output_io.respond_to?(:winsize)
+
+          output_io.winsize.last
+        rescue Errno::ENOTTY, Errno::EOPNOTSUPP
+          DEFAULT_TERMINAL_WIDTH
+        end
 
         # Start representation
         #
@@ -35,7 +50,7 @@ module Mutant
 
         # Output abstraction to decouple tty? from buffer
         class Output
-          include Anima.new(:tty, :buffer)
+          include Anima.new(:tty, :buffer, :terminal_width)
 
           # Test if output is a tty
           #
@@ -54,7 +69,7 @@ module Mutant
 
         def format(printer, object)
           buffer = new_buffer
-          printer.call(output: Output.new(tty:, buffer:), object:)
+          printer.call(output: Output.new(tty:, buffer:, terminal_width:), object:)
           buffer.rewind
           buffer.read
         end
@@ -64,6 +79,14 @@ module Mutant
 
           REPORT_FREQUENCY = 1.0
           REPORT_DELAY     = 1 / REPORT_FREQUENCY
+
+          # ANSI escape sequences
+          CLEAR_LINE  = "\e[2K"
+          CURSOR_UP   = "\e[A"
+          CURSOR_DOWN = "\e[B"
+
+          # Pattern to strip ANSI escape codes for visual length calculation
+          ANSI_ESCAPE = /\e\[[0-9;]*[A-Za-z]/
 
           # Start representation
           #
@@ -83,20 +106,89 @@ module Mutant
           #
           # @return [String]
           def progress(status)
-            format(Printer::StatusProgressive, status)
+            wrap_progress { format(status_progressive_printer, status) }
           end
 
           # Progress representation
           #
           # @return [String]
           def test_progress(status)
-            format(Printer::Test::StatusProgressive, status)
+            wrap_progress { format(test_status_progressive_printer, status) }
           end
 
         private
 
           def new_buffer
             StringIO.new
+          end
+
+          def status_progressive_printer
+            tty ? Printer::StatusProgressive::Tty : Printer::StatusProgressive::Pipe
+          end
+
+          def test_status_progressive_printer
+            tty ? Printer::Test::StatusProgressive::Tty : Printer::Test::StatusProgressive::Pipe
+          end
+
+          # Wrap progress output with TTY-specific line handling
+          #
+          # Uses indicatif-style multi-line clearing to handle terminal resize:
+          # 1. Calculate how many visual lines previous content spans at current width
+          # 2. Clear all those lines using cursor movement
+          # 3. Write new content
+          #
+          # @return [String]
+          def wrap_progress
+            content = yield
+            return content unless tty
+
+            clear_seq            = clear_last_lines(visual_lines_at_width(@last_content_length, terminal_width))
+            @last_content_length = visual_length(content)
+
+            "#{clear_seq}#{content}"
+          end
+
+          # Calculate visual length of string (excluding ANSI escape sequences)
+          #
+          # @param string [String]
+          # @return [Integer]
+          def visual_length(string)
+            string.gsub(ANSI_ESCAPE, '').length
+          end
+
+          # Calculate visual lines content occupies at given terminal width
+          #
+          # @param content_length [Integer, nil]
+          # @param width [Integer]
+          # @return [Integer]
+          def visual_lines_at_width(content_length, width)
+            return 1 if width < 1
+
+            # nil.to_f = 0.0, and ceil(0.0/w).clamp(1,10) = 1
+            (content_length.to_f / width).ceil.clamp(1, 10)
+          end
+
+          # Build escape sequence to clear n lines (indicatif/console pattern)
+          #
+          # Algorithm from console crate's clear_last_lines:
+          # 1. Move cursor up (n-1) lines to reach top
+          # 2. For each line: clear it, move down (except last)
+          # 3. Move cursor back up (n-1) lines
+          #
+          # For n=1: produces "\r\e[2K" (no cursor movement needed)
+          # For n>1: moves up, clears each line with downs between, moves back up
+          #
+          # @param lines [Integer] number of lines to clear (must be >= 1)
+          # @return [String]
+          def clear_last_lines(lines)
+            buffer = StringIO.new
+            buffer << (CURSOR_UP * (lines - 1))
+            lines.times do |i|
+              buffer << "\r" << CLEAR_LINE
+              buffer << CURSOR_DOWN if i < lines - 1
+            end
+            buffer << (CURSOR_UP * (lines - 1))
+            buffer.string
           end
 
         end # Progressive

--- a/ruby/lib/mutant/reporter/cli/printer/status_progressive.rb
+++ b/ruby/lib/mutant/reporter/cli/printer/status_progressive.rb
@@ -4,10 +4,8 @@ module Mutant
   class Reporter
     class CLI
       class Printer
-        # Reporter for progressive output format on scheduler Status objects
+        # Base class for progressive status output
         class StatusProgressive < self
-          FORMAT = 'progress: %02d/%02d alive: %d runtime: %0.02fs killtime: %0.02fs mutations/s: %0.02f'
-
           delegate(
             :amount_mutation_results,
             :amount_mutations,
@@ -16,21 +14,6 @@ module Mutant
             :killtime,
             :runtime
           )
-
-          # Run printer
-          #
-          # @return [undefined]
-          def run
-            status(
-              FORMAT,
-              amount_mutation_results,
-              amount_mutations,
-              amount_mutations_alive,
-              runtime,
-              killtime,
-              mutations_per_second
-            )
-          end
 
         private
 
@@ -41,6 +24,50 @@ module Mutant
           def mutations_per_second
             amount_mutation_results / runtime
           end
+
+          # Pipe output format (non-TTY)
+          class Pipe < StatusProgressive
+            FORMAT = 'progress: %02d/%02d alive: %d runtime: %0.02fs killtime: %0.02fs mutations/s: %0.02f'
+
+            def run
+              status(
+                FORMAT,
+                amount_mutation_results,
+                amount_mutations,
+                amount_mutations_alive,
+                runtime,
+                killtime,
+                mutations_per_second
+              )
+            end
+          end # Pipe
+
+          # TTY output format with progress bar
+          class Tty < StatusProgressive
+            FORMAT              = '%s %d/%d (%5.1f%%) %s alive: %d %0.1fs %0.2f/s'
+            MAX_BAR_WIDTH       = 40
+            PREFIX              = 'RUNNING'
+            PERCENTAGE_ESTIMATE = 99.9
+
+            def run
+              bar  = ProgressBar.build(current: amount_mutation_results, total: amount_mutations, width: bar_width)
+              line = FORMAT % format_args(bar.percentage, bar.render)
+              output.write(colorize(status_color, line))
+            end
+
+          private
+
+            def format_args(percentage, bar)
+              [PREFIX, amount_mutation_results, amount_mutations, percentage, bar,
+               amount_mutations_alive, runtime, mutations_per_second]
+            end
+
+            def bar_width
+              non_bar_content = FORMAT % format_args(PERCENTAGE_ESTIMATE, nil)
+              available_width = output.terminal_width - non_bar_content.length
+              available_width.clamp(0, MAX_BAR_WIDTH)
+            end
+          end # Tty
         end # StatusProgressive
       end # Printer
     end # CLI

--- a/ruby/lib/mutant/reporter/cli/progress_bar.rb
+++ b/ruby/lib/mutant/reporter/cli/progress_bar.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Mutant
+  class Reporter
+    class CLI
+      # Visual progress bar renderer
+      #
+      # Renders nextest-style progress bars like:
+      #   45/100 (45.0%) ████████████░░░░░░░░ alive: 12 23.45s
+      class ProgressBar
+        include Anima.new(
+          :current,
+          :total,
+          :width,
+          :filled_char,
+          :empty_char
+        )
+
+        FILLED_CHAR = "\u2588" # █
+        EMPTY_CHAR  = "\u2591" # ░
+
+        DEFAULT_WIDTH = 30
+
+        # Render the progress bar string
+        #
+        # @return [String]
+        def render
+          "#{filled}#{empty}"
+        end
+
+        # Calculate percentage completion
+        #
+        # @return [Float]
+        def percentage
+          return 0.0 if total.zero?
+
+          (current.to_f / total * 100)
+        end
+
+        # Build a progress bar with defaults
+        #
+        # @param current [Integer] current progress value
+        # @param total [Integer] total value
+        # @param width [Integer] bar width in characters
+        #
+        # @return [ProgressBar]
+        def self.build(current:, total:, width: DEFAULT_WIDTH)
+          new(
+            current:,
+            total:,
+            width:,
+            filled_char: FILLED_CHAR,
+            empty_char:  EMPTY_CHAR
+          )
+        end
+
+      private
+
+        def filled_width
+          return 0 if total.zero?
+
+          [((current.to_f / total) * width).round, width].min
+        end
+
+        def empty_width
+          width - filled_width
+        end
+
+        def filled
+          filled_char * filled_width
+        end
+
+        def empty
+          empty_char * empty_width
+        end
+      end # ProgressBar
+    end # CLI
+  end # Reporter
+end # Mutant

--- a/ruby/spec/unit/mutant/reporter/cli/format/progressive_spec.rb
+++ b/ruby/spec/unit/mutant/reporter/cli/format/progressive_spec.rb
@@ -1,0 +1,473 @@
+# frozen_string_literal: true
+
+RSpec.describe Mutant::Reporter::CLI::Format::Progressive do
+  setup_shared_context
+
+  let(:output_io) { instance_double(IO, winsize: [24, initial_width]) }
+  let(:initial_width) { 80 }
+  let(:format) { described_class.new(tty: tty?, output_io:) }
+
+  # Constants for escape sequences
+  let(:clear_line)  { "\e[2K" }
+  let(:cursor_up)   { "\e[A" }
+  let(:cursor_down) { "\e[B" }
+
+  # Test status for test_progress tests
+  let(:test_env_result) do
+    Mutant::Result::TestEnv.new(
+      env:,
+      runtime:      1.0,
+      test_results: []
+    )
+  end
+
+  let(:test_status) do
+    Mutant::Parallel::Status.new(
+      active_jobs: 1,
+      done:        false,
+      payload:     test_env_result
+    )
+  end
+
+  describe '#progress' do
+    subject { format.progress(status) }
+
+    with(:env_result) { { subject_results: [] } }
+
+    context 'when tty is false' do
+      let(:tty?) { false }
+
+      it 'returns content without escape sequences' do
+        expect(subject).to match(/^progress:.*\n$/)
+        expect(subject).not_to include("\e")
+      end
+    end
+
+    context 'when tty is true' do
+      let(:tty?) { true }
+
+      it 'prefixes with simple clear on first call' do
+        expect(subject).to start_with("\r#{clear_line}")
+        expect(subject).not_to include(cursor_up)
+      end
+
+      it 'includes progress content after clear sequence' do
+        # Verify content is present, not just clear sequences
+        expect(subject).to include('RUNNING')
+        expect(subject).to include('alive:')
+      end
+
+      it 'passes tty to Output for printer colorization' do
+        # Format#format passes tty: to Output.new, which the printer uses for colorize
+        # If mutated to tty: nil, colorize won't add color codes
+        expect(subject).to include("\e[32m") # Green color code
+      end
+
+      context 'on subsequent calls with same terminal width' do
+        before { format.progress(status) }
+
+        it 'uses single-line clear (no cursor movement)' do
+          result = format.progress(status)
+          expect(result).to start_with("\r#{clear_line}")
+          expect(result).not_to include(cursor_up)
+        end
+      end
+
+      context 'when terminal shrinks causing 3-line wrap' do
+        # Content is ~82 chars (bar maxes at 40 + ~42 for other text)
+        # At width 28: ceil(82/28) = 3 lines
+        let(:initial_width) { 100 }
+
+        before do
+          format.progress(status)
+          allow(output_io).to receive(:winsize).and_return([24, 28])
+        end
+
+        it 'generates exact 3-line clear sequence' do
+          result = format.progress(status)
+          # Expected: up 2, clear+down x2, clear, up 2
+          expected_prefix = [
+            cursor_up * 2,
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}",
+            cursor_up * 2
+          ].join
+          expect(result).to start_with(expected_prefix)
+        end
+      end
+
+      context 'when terminal shrinks causing 4-line wrap' do
+        # Content is ~82 chars. At width 21: ceil(82/21) = 4 lines
+        let(:initial_width) { 120 }
+
+        before do
+          format.progress(status)
+          allow(output_io).to receive(:winsize).and_return([24, 21])
+        end
+
+        it 'generates exact 4-line clear sequence' do
+          result = format.progress(status)
+          # Expected: up 3, clear+down x3, clear, up 3
+          expected_prefix = [
+            cursor_up * 3,
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}",
+            cursor_up * 3
+          ].join
+          expect(result).to start_with(expected_prefix)
+        end
+      end
+
+      context 'when terminal shrinks significantly' do
+        # Content is ~82 chars. At width 17: ceil(82/17) = 5 lines
+        let(:initial_width) { 120 }
+
+        before do
+          format.progress(status)
+          allow(output_io).to receive(:winsize).and_return([24, 17])
+        end
+
+        it 'generates exact 5-line clear sequence' do
+          result = format.progress(status)
+          # Expected: up 4, clear+down x4, clear, up 4
+          expected_prefix = [
+            cursor_up * 4,
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}#{cursor_down}",
+            "\r#{clear_line}",
+            cursor_up * 4
+          ].join
+          expect(result).to start_with(expected_prefix)
+        end
+      end
+    end
+  end
+
+  describe '#visual_lines_at_width (via progress)' do
+    let(:tty?) { true }
+
+    context 'with nil content_length (first call)' do
+      it 'returns 1 line (simple clear only)' do
+        result = format.progress(status)
+        expect(result).to start_with("\r#{clear_line}")
+        expect(result).not_to include(cursor_up)
+      end
+    end
+
+    context 'with width < 1' do
+      before do
+        format.progress(status)
+        allow(output_io).to receive(:winsize).and_return([24, 0])
+      end
+
+      it 'clamps to 1 line (avoids division by zero)' do
+        result = format.progress(status)
+        expect(result).to start_with("\r#{clear_line}")
+        expect(result).not_to include(cursor_up)
+      end
+    end
+
+    context 'with width of 1' do
+      before do
+        format.progress(status)
+        allow(output_io).to receive(:winsize).and_return([24, 1])
+      end
+
+      it 'clamps to max 10 lines' do
+        result = format.progress(status)
+        # With 80 chars at width 1 = 80 lines, but clamped to 10
+        expect(result.scan(cursor_up).length).to eq(9 + 9) # 9 up at start, 9 up at end
+      end
+    end
+
+    context 'ceil is required for fractional line counts' do
+      # Content ~82 chars. At width 55: 82/55 = 1.49
+      # With ceil: ceil(1.49) = 2 lines
+      # Without ceil: 1.49.clamp(1,10) = 1.49 (not an integer, would fail in times)
+      let(:initial_width) { 100 }
+
+      before do
+        format.progress(status)
+        allow(output_io).to receive(:winsize).and_return([24, 55])
+      end
+
+      it 'rounds up fractional content/width to integer lines' do
+        result = format.progress(status)
+        # Must be 2 lines: up 1, clear+down, clear, up 1
+        expected_2_line = [
+          cursor_up,
+          "\r#{clear_line}#{cursor_down}",
+          "\r#{clear_line}",
+          cursor_up
+        ].join
+        expect(result).to start_with(expected_2_line)
+      end
+    end
+
+    context 'division by width is required' do
+      # Content ~82 chars. At width 42: 82/42 = 1.95, ceil = 2
+      # Without /width: ceil(82.0).clamp(1,10) = 10 (wrong)
+      let(:initial_width) { 100 }
+
+      before do
+        format.progress(status)
+        allow(output_io).to receive(:winsize).and_return([24, 42])
+      end
+
+      it 'divides content length by width to get line count' do
+        result = format.progress(status)
+        # Must be 2 lines (not 10), proving division happened
+        expected_2_line = [
+          cursor_up,
+          "\r#{clear_line}#{cursor_down}",
+          "\r#{clear_line}",
+          cursor_up
+        ].join
+        expect(result).to start_with(expected_2_line)
+      end
+    end
+  end
+
+  describe '#clear_last_lines (via progress)' do
+    let(:tty?) { true }
+
+    context 'when lines == 1' do
+      before { format.progress(status) }
+
+      it 'returns simple clear sequence' do
+        result = format.progress(status)
+        expect(result).to start_with("\r#{clear_line}")
+        expect(result).not_to include(cursor_up)
+        expect(result).not_to include(cursor_down)
+      end
+    end
+
+    context 'when lines == 2' do
+      # Content ~82 chars. At width 42: ceil(82/42) = 2 lines
+      let(:initial_width) { 100 }
+
+      before do
+        format.progress(status)
+        allow(output_io).to receive(:winsize).and_return([24, 42])
+      end
+
+      it 'builds exact 2-line clear sequence' do
+        result = format.progress(status)
+        # lines=2: up 1, (clear, down), clear, up 1
+        expected_clear = [
+          cursor_up, # move up 1
+          "\r#{clear_line}#{cursor_down}", # clear line 1, move down
+          "\r#{clear_line}", # clear line 2
+          cursor_up # move back up 1
+        ].join
+        expect(result).to start_with(expected_clear)
+      end
+    end
+
+    context 'when lines == 3' do
+      # Content ~82 chars. At width 28: ceil(82/28) = 3 lines
+      let(:initial_width) { 100 }
+
+      before do
+        format.progress(status)
+        allow(output_io).to receive(:winsize).and_return([24, 28])
+      end
+
+      it 'builds exact 3-line clear sequence' do
+        result = format.progress(status)
+        # lines=3: up 2, (clear, down) x2, clear, up 2
+        expected_clear = [
+          cursor_up * 2,
+          "\r#{clear_line}#{cursor_down}",
+          "\r#{clear_line}#{cursor_down}",
+          "\r#{clear_line}",
+          cursor_up * 2
+        ].join
+        expect(result).to start_with(expected_clear)
+      end
+    end
+  end
+
+  describe '#visual_length (via progress)' do
+    let(:tty?) { true }
+
+    context 'with content containing ANSI codes' do
+      before { format.progress(status) }
+
+      it 'calculates length excluding ANSI codes for same-width case' do
+        # Second call with same width should use single-line clear
+        result = format.progress(status)
+        expect(result).to start_with("\r#{clear_line}")
+        expect(result).not_to include(cursor_up)
+      end
+
+      it 'correctly affects line calculation when terminal shrinks' do
+        # Content is ~82 visual chars (ignoring ANSI codes which add ~9 bytes)
+        # If visual_length incorrectly included ANSI codes (~91 bytes),
+        # at width 46, it would be ceil(91/46)=2 lines instead of ceil(82/46)=2
+        # But at width 43, with ANSI: ceil(91/43)=3, without: ceil(82/43)=2
+        # So we use width 43 to distinguish correct vs incorrect behavior
+        allow(output_io).to receive(:winsize).and_return([24, 43])
+        result = format.progress(status)
+
+        # If visual_length works correctly (82 chars), at width 43 = 2 lines
+        # 2 lines: up 1, clear+down, clear, up 1
+        expected_2_line = [
+          cursor_up,
+          "\r#{clear_line}#{cursor_down}",
+          "\r#{clear_line}",
+          cursor_up
+        ].join
+        expect(result).to start_with(expected_2_line)
+      end
+    end
+
+    context 'when visual_length return value affects line count' do
+      # This test ensures visual_length returns an Integer that affects calculations
+      # Content is ~82 visual chars. At width 28: ceil(82/28) = 3 lines
+      # If visual_length returned nil, visual_lines_at_width would return 1
+      let(:initial_width) { 100 }
+
+      before do
+        format.progress(status)
+        allow(output_io).to receive(:winsize).and_return([24, 28])
+      end
+
+      it 'produces multi-line clear proving visual_length returns a meaningful value' do
+        result = format.progress(status)
+        # Must have cursor movement, proving visual_length returned something > 28
+        expect(result).to include(cursor_up)
+        expect(result.scan(cursor_up).length).to be >= 4 # 2 at start + 2 at end
+      end
+    end
+  end
+
+  describe '#test_progress' do
+    subject { format.test_progress(test_status) }
+
+    context 'when tty is false' do
+      let(:tty?) { false }
+
+      it 'returns content without escape sequences' do
+        expect(subject).to match(/^progress:.*\n$/)
+        expect(subject).not_to include("\e")
+      end
+    end
+
+    context 'when tty is true' do
+      let(:tty?) { true }
+
+      it 'prefixes with simple clear on first call' do
+        expect(subject).to start_with("\r#{clear_line}")
+        expect(subject).not_to include(cursor_up)
+      end
+
+      it 'includes test progress content after clear sequence' do
+        expect(subject).to include('TESTING')
+        expect(subject).to include('failed:')
+      end
+
+      it 'passes tty to Output for printer colorization' do
+        # Format#format passes tty: to Output.new, which the printer uses for colorize
+        # If mutated to tty: nil, colorize won't add color codes
+        expect(subject).to include("\e[32m") # Green color code
+      end
+
+      context 'on subsequent calls with same terminal width' do
+        before { format.test_progress(test_status) }
+
+        it 'uses single-line clear (no cursor movement)' do
+          result = format.test_progress(test_status)
+          expect(result).to start_with("\r#{clear_line}")
+          expect(result).not_to include(cursor_up)
+        end
+      end
+
+      context 'when terminal shrinks causing multi-line wrap' do
+        let(:initial_width) { 100 }
+
+        before do
+          format.test_progress(test_status)
+          allow(output_io).to receive(:winsize).and_return([24, 28])
+        end
+
+        it 'generates multi-line clear sequence' do
+          result = format.test_progress(test_status)
+          expect(result).to include(cursor_up)
+          expect(result).to include(clear_line)
+        end
+      end
+    end
+  end
+
+  describe '#terminal_width' do
+    context 'when tty is true and output_io responds to winsize' do
+      let(:tty?) { true }
+
+      it 'returns the terminal width from winsize' do
+        expect(format.terminal_width).to eq(initial_width)
+      end
+
+      it 'queries winsize dynamically' do
+        expect(format.terminal_width).to eq(80)
+        allow(output_io).to receive(:winsize).and_return([24, 120])
+        expect(format.terminal_width).to eq(120)
+      end
+    end
+
+    context 'when tty is false' do
+      let(:tty?) { false }
+
+      it 'returns DEFAULT_TERMINAL_WIDTH' do
+        expect(format.terminal_width).to eq(80)
+      end
+
+      it 'does not call winsize' do
+        format.terminal_width
+        expect(output_io).not_to have_received(:winsize) if output_io.respond_to?(:winsize)
+      end
+    end
+
+    context 'when output_io does not respond to winsize' do
+      let(:tty?) { true }
+      let(:output_io) { instance_double(IO) }
+
+      before do
+        allow(output_io).to receive(:respond_to?).with(:winsize).and_return(false)
+      end
+
+      it 'returns DEFAULT_TERMINAL_WIDTH' do
+        expect(format.terminal_width).to eq(80)
+      end
+    end
+
+    context 'when winsize raises Errno::ENOTTY' do
+      let(:tty?) { true }
+
+      before do
+        allow(output_io).to receive(:winsize).and_raise(Errno::ENOTTY)
+      end
+
+      it 'returns DEFAULT_TERMINAL_WIDTH' do
+        expect(format.terminal_width).to eq(80)
+      end
+    end
+
+    context 'when winsize raises Errno::EOPNOTSUPP' do
+      let(:tty?) { true }
+
+      before do
+        allow(output_io).to receive(:winsize).and_raise(Errno::EOPNOTSUPP)
+      end
+
+      it 'returns DEFAULT_TERMINAL_WIDTH' do
+        expect(format.terminal_width).to eq(80)
+      end
+    end
+  end
+end

--- a/ruby/spec/unit/mutant/reporter/cli/printer/status_progressive_spec.rb
+++ b/ruby/spec/unit/mutant/reporter/cli/printer/status_progressive_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Mutant::Reporter::CLI::Printer::StatusProgressive do
+RSpec.describe Mutant::Reporter::CLI::Printer::StatusProgressive::Pipe do
   setup_shared_context
 
   let(:reportable) { status }

--- a/ruby/spec/unit/mutant/reporter/cli/printer/status_progressive_tty_spec.rb
+++ b/ruby/spec/unit/mutant/reporter/cli/printer/status_progressive_tty_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe Mutant::Reporter::CLI::Printer::StatusProgressive::Tty do
+  setup_shared_context
+
+  let(:reportable)      { status }
+  let(:terminal_width)  { 80 }
+  let(:output)          { format_output }
+
+  def format_output
+    Mutant::Reporter::CLI::Format::Output.new(
+      tty:            true,
+      buffer:         StringIO.new,
+      terminal_width:
+    )
+  end
+
+  def self.it_reports(expected_content)
+    it 'writes expected report to output' do
+      described_class.call(output:, object: reportable)
+      output.buffer.rewind
+      expect(output.buffer.read).to eql(expected_content)
+    end
+  end
+
+  describe '.call' do
+    context 'with empty scheduler' do
+      with(:env_result) { { subject_results: [] } }
+
+      # rubocop:disable Layout/LineLength
+      it_reports Unparser::Color::GREEN.format('RUNNING 0/2 (  0.0%) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ alive: 0 4.0s 0.00/s')
+      # rubocop:enable Layout/LineLength
+    end
+
+    context 'with scheduler active on one subject' do
+      with(:status) { { active_jobs: [job_b, job_a].to_set } }
+
+      context 'on failure' do
+        with(:mutation_a_criteria_result) { { test_result: false } }
+
+        # rubocop:disable Layout/LineLength
+        it_reports Unparser::Color::RED.format('RUNNING 2/2 (100.0%) ██████████████████████████████████████ alive: 1 4.0s 0.50/s')
+        # rubocop:enable Layout/LineLength
+      end
+
+      context 'on success' do
+        # rubocop:disable Layout/LineLength
+        it_reports Unparser::Color::GREEN.format('RUNNING 2/2 (100.0%) ██████████████████████████████████████ alive: 0 4.0s 0.50/s')
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
+    context 'with narrow terminal' do
+      let(:terminal_width) { 50 }
+
+      with(:env_result) { { subject_results: [] } }
+
+      # Bar shrinks to fit available space
+      it_reports Unparser::Color::GREEN.format('RUNNING 0/2 (  0.0%) ░░░░░░░░ alive: 0 4.0s 0.00/s')
+    end
+
+    context 'with very narrow terminal' do
+      # Terminal so narrow that bar width would be negative, clamped to 0
+      let(:terminal_width) { 40 }
+
+      with(:env_result) { { subject_results: [] } }
+
+      # Bar width is 0 (clamped from negative available_width)
+      it_reports Unparser::Color::GREEN.format('RUNNING 0/2 (  0.0%)  alive: 0 4.0s 0.00/s')
+    end
+
+    context 'with wide terminal' do
+      let(:terminal_width) { 200 }
+
+      with(:env_result) { { subject_results: [] } }
+
+      # rubocop:disable Layout/LineLength
+      it_reports Unparser::Color::GREEN.format('RUNNING 0/2 (  0.0%) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ alive: 0 4.0s 0.00/s')
+      # rubocop:enable Layout/LineLength
+    end
+  end
+end

--- a/ruby/spec/unit/mutant/reporter/cli/printer/test/status_progressive_spec.rb
+++ b/ruby/spec/unit/mutant/reporter/cli/printer/test/status_progressive_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Mutant::Reporter::CLI::Printer::Test::StatusProgressive do
+RSpec.describe Mutant::Reporter::CLI::Printer::Test::StatusProgressive::Pipe do
   setup_shared_context
 
   let(:reportable) { test_status }

--- a/ruby/spec/unit/mutant/reporter/cli/printer/test/status_progressive_tty_spec.rb
+++ b/ruby/spec/unit/mutant/reporter/cli/printer/test/status_progressive_tty_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+RSpec.describe Mutant::Reporter::CLI::Printer::Test::StatusProgressive::Tty do
+  setup_shared_context
+
+  let(:reportable)      { test_status }
+  let(:test_results)    { [] }
+  let(:terminal_width)  { 80 }
+  let(:output)          { format_output }
+
+  def format_output
+    Mutant::Reporter::CLI::Format::Output.new(
+      tty:            true,
+      buffer:         StringIO.new,
+      terminal_width:
+    )
+  end
+
+  def self.it_reports(expected_content)
+    it 'writes expected report to output' do
+      described_class.call(output:, object: reportable)
+      output.buffer.rewind
+      expect(output.buffer.read).to eql(expected_content)
+    end
+  end
+
+  let(:test_env) do
+    Mutant::Result::TestEnv.new(
+      env:,
+      runtime:      0.8,
+      test_results:
+    )
+  end
+
+  let(:test_status) do
+    Mutant::Parallel::Status.new(
+      active_jobs: 1,
+      done:        false,
+      payload:     test_env
+    )
+  end
+
+  describe '.call' do
+    context 'with empty scheduler' do
+      # rubocop:disable Layout/LineLength
+      it_reports Unparser::Color::GREEN.format('TESTING 0/2 (  0.0%) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ failed: 0 0.8s 0.00/s')
+      # rubocop:enable Layout/LineLength
+    end
+
+    context 'with test results' do
+      let(:test_results) do
+        [
+          Mutant::Result::Test.new(
+            job_index: 0,
+            output:    '',
+            passed:    false,
+            runtime:   0.5
+          )
+        ]
+      end
+
+      # rubocop:disable Layout/LineLength
+      it_reports Unparser::Color::RED.format('TESTING 1/2 ( 50.0%) ███████████████████░░░░░░░░░░░░░░░░░░ failed: 1 0.8s 1.25/s')
+      # rubocop:enable Layout/LineLength
+    end
+
+    context 'with narrow terminal' do
+      let(:terminal_width) { 50 }
+
+      # Bar shrinks to fit available space
+      it_reports Unparser::Color::GREEN.format('TESTING 0/2 (  0.0%) ░░░░░░░ failed: 0 0.8s 0.00/s')
+    end
+
+    context 'with very narrow terminal' do
+      # Terminal so narrow that bar width would be negative, clamped to 0
+      let(:terminal_width) { 40 }
+
+      # Bar width is 0 (clamped from negative available_width)
+      it_reports Unparser::Color::GREEN.format('TESTING 0/2 (  0.0%)  failed: 0 0.8s 0.00/s')
+    end
+
+    context 'with wide terminal' do
+      let(:terminal_width) { 200 }
+
+      # rubocop:disable Layout/LineLength
+      it_reports Unparser::Color::GREEN.format('TESTING 0/2 (  0.0%) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ failed: 0 0.8s 0.00/s')
+      # rubocop:enable Layout/LineLength
+    end
+  end
+end

--- a/ruby/spec/unit/mutant/reporter/cli/progress_bar_spec.rb
+++ b/ruby/spec/unit/mutant/reporter/cli/progress_bar_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+RSpec.describe Mutant::Reporter::CLI::ProgressBar do
+  describe '.build' do
+    subject { described_class.build(current:, total:) }
+
+    let(:current) { 5 }
+    let(:total)   { 10 }
+
+    it 'creates a progress bar with default settings' do
+      expect(subject).to be_a(described_class)
+    end
+
+    it 'sets current from parameter' do
+      expect(subject.current).to eql(current)
+    end
+
+    it 'sets total from parameter' do
+      expect(subject.total).to eql(total)
+    end
+
+    it 'uses DEFAULT_WIDTH for width' do
+      expect(subject.width).to eql(described_class::DEFAULT_WIDTH)
+    end
+
+    it 'uses FILLED_CHAR for filled_char' do
+      expect(subject.filled_char).to eql(described_class::FILLED_CHAR)
+    end
+
+    it 'uses EMPTY_CHAR for empty_char' do
+      expect(subject.empty_char).to eql(described_class::EMPTY_CHAR)
+    end
+
+    context 'with custom width' do
+      subject { described_class.build(current:, total:, width: 20) }
+
+      it 'uses provided width' do
+        expect(subject.width).to eql(20)
+      end
+    end
+  end
+
+  describe '#render' do
+    subject { progress_bar.render }
+
+    let(:progress_bar) { described_class.build(current:, total:, width:) }
+    let(:width)        { 10 }
+
+    context 'when progress is 0%' do
+      let(:current) { 0 }
+      let(:total)   { 100 }
+
+      it 'renders empty bar' do
+        expect(subject).to eql('░░░░░░░░░░')
+      end
+    end
+
+    context 'when progress is 50%' do
+      let(:current) { 50 }
+      let(:total)   { 100 }
+
+      it 'renders half-filled bar' do
+        expect(subject).to eql('█████░░░░░')
+      end
+    end
+
+    context 'when rounding affects filled_width' do
+      # 46/100 * 10 = 4.6, rounds to 5
+      let(:current) { 46 }
+      let(:total)   { 100 }
+
+      it 'rounds filled width correctly' do
+        expect(subject).to eql('█████░░░░░')
+      end
+    end
+
+    context 'when rounding down affects filled_width' do
+      # 44/100 * 10 = 4.4, rounds to 4
+      let(:current) { 44 }
+      let(:total)   { 100 }
+
+      it 'rounds filled width correctly' do
+        expect(subject).to eql('████░░░░░░')
+      end
+    end
+
+    context 'when progress is 100%' do
+      let(:current) { 100 }
+      let(:total)   { 100 }
+
+      it 'renders fully filled bar' do
+        expect(subject).to eql('██████████')
+      end
+    end
+
+    context 'when total is 0' do
+      let(:current) { 0 }
+      let(:total)   { 0 }
+
+      it 'renders empty bar' do
+        expect(subject).to eql('░░░░░░░░░░')
+      end
+    end
+
+    context 'when progress exceeds total' do
+      let(:current) { 150 }
+      let(:total)   { 100 }
+
+      it 'renders fully filled bar' do
+        expect(subject).to eql('██████████')
+      end
+    end
+  end
+
+  describe '#percentage' do
+    subject { progress_bar.percentage }
+
+    let(:progress_bar) { described_class.build(current:, total:) }
+
+    context 'when progress is 0%' do
+      let(:current) { 0 }
+      let(:total)   { 100 }
+
+      it { should eql(0.0) }
+    end
+
+    context 'when progress is 50%' do
+      let(:current) { 50 }
+      let(:total)   { 100 }
+
+      it { should eql(50.0) }
+    end
+
+    context 'when progress is 100%' do
+      let(:current) { 100 }
+      let(:total)   { 100 }
+
+      it { should eql(100.0) }
+    end
+
+    context 'when total is 0' do
+      let(:current) { 0 }
+      let(:total)   { 0 }
+
+      it { should eql(0.0) }
+    end
+  end
+end


### PR DESCRIPTION
Replace periodic text-based progress output with a (nextest-style) progress bar that updates in place when running in a TTY. It looks something like this:

```
RUNNING 45/100 (45.0%) ████████████░░░░░░░░░░░░ alive: 12 23.4s 1.89/s
```

It falls back to text format for non-TTY output.

Squashed from https://github.com/mbj/mutant/pull/1510#issuecomment-3760128446.