### PR TITLE
Add bitwise operator mutations

### DIFF
--- a/ruby/lib/mutant/mutation/operators.rb
+++ b/ruby/lib/mutant/mutation/operators.rb
@@ -10,13 +10,18 @@ module Mutant
         NAME = :full
 
         SELECTOR_REPLACEMENTS = {
+          :& =>          %i[| ^],
           :< =>          %i[== eql? equal?],
+          :<< =>         %i[>>],
           :<= =>         %i[< == eql? equal?],
           :== =>         %i[eql? equal?],
           :=== =>        %i[is_a?],
           :=~ =>         %i[match?],
           :> =>          %i[== eql? equal?],
           :>= =>         %i[> == eql? equal?],
+          :>> =>         %i[<<],
+          :^ =>          %i[& |],
+          :| =>          %i[& ^],
           __send__:      %i[public_send],
           all?:          %i[any?],
           any?:          %i[all?],

--- a/ruby/meta/block.rb
+++ b/ruby/meta/block.rb
@@ -83,6 +83,7 @@ Mutant::Meta::Example.add :block do
 
   singleton_mutations
   mutation 'foo { self << false }'
+  mutation 'foo { self >> true }'
   mutation 'foo { nil << true }'
   mutation 'foo { nil }'
   mutation 'foo { self }'

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -529,7 +529,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo(n..-2)'
 end
 
-(Mutant::AST::Types::BINARY_METHOD_OPERATORS - %i[=~ <= >= < > == === != eql?]).each do |operator|
+(Mutant::AST::Types::BINARY_METHOD_OPERATORS - %i[=~ <= >= < > == === != eql? & | ^ << >>]).each do |operator|
   Mutant::Meta::Example.add :send do
     source "true #{operator} false"
 
@@ -539,6 +539,69 @@ end
     mutation "false #{operator} false"
     mutation "true  #{operator} true"
   end
+end
+
+# Bitwise AND operator
+Mutant::Meta::Example.add :send do
+  source 'a & b'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'b'
+  mutation 'nil & b'
+  mutation 'a & nil'
+  mutation 'a | b'
+  mutation 'a ^ b'
+end
+
+# Bitwise OR operator
+Mutant::Meta::Example.add :send do
+  source 'a | b'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'b'
+  mutation 'nil | b'
+  mutation 'a | nil'
+  mutation 'a & b'
+  mutation 'a ^ b'
+end
+
+# Bitwise XOR operator
+Mutant::Meta::Example.add :send do
+  source 'a ^ b'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'b'
+  mutation 'nil ^ b'
+  mutation 'a ^ nil'
+  mutation 'a & b'
+  mutation 'a | b'
+end
+
+# Left shift operator
+Mutant::Meta::Example.add :send do
+  source 'a << b'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'b'
+  mutation 'nil << b'
+  mutation 'a << nil'
+  mutation 'a >> b'
+end
+
+# Right shift operator
+Mutant::Meta::Example.add :send do
+  source 'a >> b'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'b'
+  mutation 'nil >> b'
+  mutation 'a >> nil'
+  mutation 'a << b'
 end
 
 Mutant::Meta::Example.add :send do


### PR DESCRIPTION
Implement selector replacements for bitwise operators:
* `&` (AND) mutates to `|` and `^`
* `|` (OR) mutates to `&` and `^`
* `^` (XOR) mutates to `&` and `|`
* `<<` (left shift) mutates to `>>`
* `>>` (right shift) mutates to `<<`