### PR TITLE
Add mutations for (some) arithmetic operators

### DIFF
--- a/ruby/lib/mutant/mutation/operators.rb
+++ b/ruby/lib/mutant/mutation/operators.rb
@@ -11,6 +11,8 @@ module Mutant
 
         SELECTOR_REPLACEMENTS = {
           :& =>          %i[| ^],
+          :+ =>          %i[-],
+          :- =>          %i[+],
           :< =>          %i[== eql? equal?],
           :<< =>         %i[>>],
           :<= =>         %i[< == eql? equal?],

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -501,17 +501,20 @@ Mutant::Meta::Example.add :send do
 end
 
 Mutant::Meta::Example.add :send do
-  source '(left - right) / foo'
+  source '(left - right) + foo'
 
   singleton_mutations
   mutation 'foo'
   mutation '(left - right)'
-  mutation '(left) / foo'
-  mutation '(right) / foo'
-  mutation '(left - right) / nil'
-  mutation '(left - nil) / foo'
-  mutation '(nil - right) / foo'
-  mutation '(nil) / foo'
+  mutation '(left) + foo'
+  mutation '(right) + foo'
+  mutation '(left - right) + nil'
+  mutation '(left - nil) + foo'
+  mutation '(nil - right) + foo'
+  mutation '(nil) + foo'
+  # Arithmetic operator mutations
+  mutation '(left - right) - foo'
+  mutation '(left + right) + foo'
 end
 
 Mutant::Meta::Example.add :send do
@@ -529,7 +532,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo(n..-2)'
 end
 
-(Mutant::AST::Types::BINARY_METHOD_OPERATORS - %i[=~ <= >= < > == === != eql? & | ^ << >>]).each do |operator|
+(Mutant::AST::Types::BINARY_METHOD_OPERATORS - %i[=~ <= >= < > == === != eql? & | ^ << >> + - * / %]).each do |operator|
   Mutant::Meta::Example.add :send do
     source "true #{operator} false"
 
@@ -539,6 +542,30 @@ end
     mutation "false #{operator} false"
     mutation "true  #{operator} true"
   end
+end
+
+# Addition operator
+Mutant::Meta::Example.add :send do
+  source 'a + b'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'b'
+  mutation 'nil + b'
+  mutation 'a + nil'
+  mutation 'a - b'
+end
+
+# Subtraction operator
+Mutant::Meta::Example.add :send do
+  source 'a - b'
+
+  singleton_mutations
+  mutation 'a'
+  mutation 'b'
+  mutation 'nil - b'
+  mutation 'a - nil'
+  mutation 'a + b'
 end
 
 # Bitwise AND operator
@@ -924,6 +951,8 @@ Mutant::Meta::Example.add :send do
   mutation 'self.reduce(INITIAL, &:+)'
   mutation 'a.reduce(INITIAL, &:"+__mutant__")'
   mutation 'a.sum(INITIAL)'
+  # Arithmetic operator mutations for block_pass symbol
+  mutation 'a.reduce(INITIAL, &:-)'
 end
 
 Mutant::Meta::Example.add :send do


### PR DESCRIPTION
This patch adds the following mutations:

* `+` mutates to `-` and `*`
* `-` mutates to `+` and `/`

NOTE: This patch originally mutated `*` to `/` (and vice versa) but I backed out those changes since multiplication and division by 1 or -1 are equivalent and I couldn't figure out how to exclude those cases while maintaining 100% mutation coverage. I also originally had compound assignment mutations (`+=`, `-=`, etc.) in this patch, but I will make that a separate patch.