### PR TITLE
Add break → next mutation for symmetry with next → break

### DIFF
--- a/ruby/lib/mutant/mutator/node/break.rb
+++ b/ruby/lib/mutant/mutator/node/break.rb
@@ -15,6 +15,7 @@ module Mutant
           super
           emit_singletons
           children.each_index(&method(:delete_child))
+          emit(s(:next, *children))
         end
 
       end # Break

--- a/ruby/meta/block.rb
+++ b/ruby/meta/block.rb
@@ -131,6 +131,7 @@ Mutant::Meta::Example.add :block do
   mutation 'foo { nil if true }'
   mutation 'foo { break if false }'
   mutation 'foo { break }'
+  mutation 'foo { next if true }'
 end
 
 Mutant::Meta::Example.add :block do
@@ -139,6 +140,7 @@ Mutant::Meta::Example.add :block do
   singleton_mutations
   mutation 'foo { nil }'
   mutation 'foo { raise }'
+  mutation 'foo { next }'
   mutation 'foo { }'
   mutation 'foo'
 end

--- a/ruby/meta/break.rb
+++ b/ruby/meta/break.rb
@@ -6,4 +6,5 @@ Mutant::Meta::Example.add :break do
   singleton_mutations
   mutation 'break false'
   mutation 'break'
+  mutation 'next true'
 end


### PR DESCRIPTION
The `next` → `break` mutation already exists, but the reverse was missing. This adds the `break` → `next` mutation to provide bidirectional coverage for loop control flow mutations.