### PR TITLE
Add empty collection return value mutations

### DIFF
--- a/ruby/lib/mutant/ast/named_children.rb
+++ b/ruby/lib/mutant/ast/named_children.rb
@@ -55,10 +55,6 @@ module Mutant
         #
         # @return [undefined]
         def define_remaining_children(names)
-          define_private_method(:remaining_children_with_index) do
-            children.each_with_index.drop(names.length)
-          end
-
           define_private_method(:remaining_children_indices) do
             children.each_index.drop(names.length)
           end

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -27,6 +27,21 @@ Mutant::Meta::Example.add :send do
 end
 
 Mutant::Meta::Example.add :send do
+  source 'A.const_get(:B, false)'
+
+  singleton_mutations
+  mutation 'A::B'
+  mutation 'A.const_get(:B)'
+  mutation 'A.const_get(false)'
+  mutation 'A.const_get'
+  mutation 'A'
+  mutation 'A.const_get(nil, false)'
+  mutation 'A.const_get(:B__mutant__, false)'
+  mutation 'A.const_get(:B, true)'
+  mutation 'self.const_get(:B, false)'
+end
+
+Mutant::Meta::Example.add :send do
   source 'A.const_get(bar)'
 
   singleton_mutations
@@ -149,6 +164,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'self.to_s'
   mutation 'foo.to_str'
+  mutation '""'
 end
 
 Mutant::Meta::Example.add :send do
@@ -158,6 +174,7 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'self.to_a'
   mutation 'foo.to_ary'
+  mutation '[]'
 end
 
 Mutant::Meta::Example.add :send do
@@ -177,6 +194,34 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'self.to_h'
   mutation 'foo.to_hash'
+  mutation '{}'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.to_ary'
+
+  singleton_mutations
+  mutation 'foo'
+  mutation 'self.to_ary'
+  mutation '[]'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.to_hash'
+
+  singleton_mutations
+  mutation 'foo'
+  mutation 'self.to_hash'
+  mutation '{}'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.to_str'
+
+  singleton_mutations
+  mutation 'foo'
+  mutation 'self.to_str'
+  mutation '""'
 end
 
 Mutant::Meta::Example.add :send, operators: :full do

--- a/ruby/spec/unit/mutant/ast/named_children_spec.rb
+++ b/ruby/spec/unit/mutant/ast/named_children_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Mutant::AST::NamedChildren do
       klass.class_eval do
         public :foo, :bar
 
-        public :remaining_children, :remaining_children_indices, :remaining_children_with_index
+        public :remaining_children, :remaining_children_indices
       end
     end
 
@@ -33,7 +33,6 @@ RSpec.describe Mutant::AST::NamedChildren do
           bar
           remaining_children
           remaining_children_indices
-          remaining_children_with_index
         ].each do |name|
           expect(klass.private_method_defined?(name)).to be(true)
         end
@@ -50,13 +49,6 @@ RSpec.describe Mutant::AST::NamedChildren do
         it 'returns remaining unnamed children indices' do
           publish
           expect(instance.remaining_children_indices).to eql([2])
-        end
-      end
-
-      describe '#remaining_children_with_index' do
-        it 'returns remaining unnamed children indices' do
-          publish
-          expect(instance.remaining_children_with_index).to eql([[node_baz, 2]])
         end
       end
 


### PR DESCRIPTION
Add mutations that replace collection-returning expressions with empty values.

* `to_a`/`to_ary` calls mutate to empty array
* `to_h`/`to_hash` calls mutate to empty hash
* `to_s`/`to_str` calls mutate to empty string
* String literals mutate to empty string