### PR TITLE
Add compound assignment operator swap mutations

### DIFF
--- a/ruby/lib/mutant/mutator/node/op_asgn.rb
+++ b/ruby/lib/mutant/mutator/node/op_asgn.rb
@@ -11,12 +11,32 @@ module Mutant
 
         children :left, :operation, :right
 
+        OPERATOR_SWAPS = {
+          :+  => %i[-],
+          :-  => %i[+],
+          :*  => %i[/],
+          :/  => %i[*],
+          :%  => %i[/],
+          :** => %i[*],
+          :&  => %i[|],
+          :|  => %i[&],
+          :^  => %i[&],
+          :<< => %i[>>],
+          :>> => %i[<<]
+        }.each_value(&:freeze).freeze
+
       private
 
         def dispatch
           left_mutations
-
+          emit_operator_replacements
           emit_right_mutations
+        end
+
+        def emit_operator_replacements
+          OPERATOR_SWAPS.fetch(operation).each do |replacement|
+            emit_operation(replacement)
+          end
         end
 
         def left_mutations

--- a/ruby/meta/indexasgn.rb
+++ b/ruby/meta/indexasgn.rb
@@ -22,4 +22,5 @@ Mutant::Meta::Example.add :indexasgn, :op_asgn do
   mutation 'self[] += bar'
   mutation 'self[nil] += bar'
   mutation 'self[foo] += nil'
+  mutation 'self[foo] -= bar'
 end

--- a/ruby/meta/op_assgn.rb
+++ b/ruby/meta/op_assgn.rb
@@ -7,6 +7,7 @@ Mutant::Meta::Example.add :op_asgn, :send do
   mutation '@a.b += 0'
   mutation '@a.b += 2'
   mutation '@a.b += nil'
+  mutation '@a.b -= 1'
   mutation 'self.b += 1'
 end
 
@@ -16,6 +17,7 @@ Mutant::Meta::Example.add :op_asgn, :send do
   mutation 'a.b += 0'
   mutation 'a.b += 2'
   mutation 'a.b += nil'
+  mutation 'a.b -= 1'
   mutation 'self.b += 1'
 end
 
@@ -25,4 +27,103 @@ Mutant::Meta::Example.add :op_asgn, :send do
   mutation 'b += 0'
   mutation 'b += 2'
   mutation 'b += nil'
+  mutation 'b -= 1'
+end
+
+# Subtraction operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a -= 1'
+
+  mutation 'a -= 0'
+  mutation 'a -= 2'
+  mutation 'a -= nil'
+  mutation 'a += 1'
+end
+
+# Multiplication operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a *= 2'
+
+  mutation 'a *= nil'
+  mutation 'a *= 0'
+  mutation 'a *= 1'
+  mutation 'a *= 3'
+  mutation 'a /= 2'
+end
+
+# Division operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a /= 2'
+
+  mutation 'a /= nil'
+  mutation 'a /= 0'
+  mutation 'a /= 1'
+  mutation 'a /= 3'
+  mutation 'a *= 2'
+end
+
+# Modulo operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a %= 2'
+
+  mutation 'a %= nil'
+  mutation 'a %= 0'
+  mutation 'a %= 1'
+  mutation 'a %= 3'
+  mutation 'a /= 2'
+end
+
+# Exponentiation operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a **= 2'
+
+  mutation 'a **= nil'
+  mutation 'a **= 0'
+  mutation 'a **= 1'
+  mutation 'a **= 3'
+  mutation 'a *= 2'
+end
+
+# Bitwise AND operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a &= b'
+
+  mutation 'a &= nil'
+  mutation 'a |= b'
+end
+
+# Bitwise OR operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a |= b'
+
+  mutation 'a |= nil'
+  mutation 'a &= b'
+end
+
+# Bitwise XOR operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a ^= b'
+
+  mutation 'a ^= nil'
+  mutation 'a &= b'
+end
+
+# Left shift operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a <<= 1'
+
+  mutation 'a <<= nil'
+  mutation 'a <<= 0'
+  mutation 'a <<= 2'
+  mutation 'a >>= 1'
+end
+
+# Right shift operator swap
+Mutant::Meta::Example.add :op_asgn do
+  source 'a >>= 1'
+
+  mutation 'a >>= nil'
+  mutation 'a >>= 0'
+  mutation 'a >>= 2'
+  mutation 'a <<= 1'
 end


### PR DESCRIPTION
Mutate compound assignment operators to their counterparts:
* `+=` ↔ `-=`
* `*=` ↔ `/=`
* `%=` → `/=`
* `**=` → `*=`
* `&=` ↔ `|=`
* `^=` → `&=`
* `<<=` ↔ `>>=`

This is a follow-up to https://github.com/mbj/mutant/pull/1523, which originally included these changes but was reduced to just add addition and subtraction swap mutations.