### PR TITLE
Add rescue clause removal mutations

### DIFF
--- a/ruby/lib/mutant/mutator/node/rescue.rb
+++ b/ruby/lib/mutant/mutator/node/rescue.rb
@@ -30,6 +30,18 @@ module Mutant
               emit_concat(resbody.body)
             end
           end
+          emit_rescue_clause_removals
+        end
+
+        def emit_rescue_clause_removals
+          rescue_indices = children_indices(RESCUE_INDICES).to_a
+          return unless rescue_indices.length > 1
+
+          rescue_indices.each do |index|
+            dup_children = children.dup
+            dup_children.delete_at(index)
+            emit_type(*dup_children)
+          end
         end
 
         def emit_concat(child)

--- a/ruby/meta/rescue.rb
+++ b/ruby/meta/rescue.rb
@@ -70,3 +70,35 @@ Mutant::Meta::Example.add :rescue do
   singleton_mutations
   mutation 'begin; rescue; ensure; false; end'
 end
+
+# Multiple rescue clauses with assignment - test individual clause removal
+Mutant::Meta::Example.add :rescue do
+  source 'def a; foo; rescue ErrorA => e; bar; rescue ErrorB => e; baz; end'
+
+  # Mutate try body
+  mutation 'def a; nil; rescue ErrorA => e; bar; rescue ErrorB => e; baz; end'
+
+  # Mutate first rescue body
+  mutation 'def a; foo; rescue ErrorA => e; nil; rescue ErrorB => e; baz; end'
+
+  # Mutate second rescue body
+  mutation 'def a; foo; rescue ErrorA => e; bar; rescue ErrorB => e; nil; end'
+
+  # Promote try body (remove all rescues)
+  mutation 'def a; foo; end'
+
+  # Empty body
+  mutation 'def a; end'
+
+  # Failing body
+  mutation 'def a; raise; end'
+
+  # Superclass implementation
+  mutation 'def a; super; end'
+
+  # Remove first rescue clause (keep second)
+  mutation 'def a; foo; rescue ErrorB => e; baz; end'
+
+  # Remove second rescue clause (keep first)
+  mutation 'def a; foo; rescue ErrorA => e; bar; end'
+end


### PR DESCRIPTION
When multiple rescue clauses exist, emit mutations that remove each clause individually. This tests that each specific exception handler is necessary and properly tested.