### PR TITLE
Add type-aware default return mutations for method bodies

### DIFF
--- a/ruby/lib/mutant/ast/nodes.rb
+++ b/ruby/lib/mutant/ast/nodes.rb
@@ -17,6 +17,11 @@ module Mutant
       N_SELF              = s(:self)
       N_ZSUPER            = s(:zsuper)
       N_EMPTY_SUPER       = s(:super)
+      N_EMPTY_ARRAY       = s(:array)
+      N_EMPTY_HASH        = s(:hash)
+      N_EMPTY_STRING      = s(:str, '')
+      N_ZERO_INTEGER      = s(:int, 0)
+      N_ZERO_FLOAT        = s(:float, 0.0)
 
     end # Nodes
   end # AST

--- a/ruby/lib/mutant/mutator/node/define.rb
+++ b/ruby/lib/mutant/mutator/node/define.rb
@@ -6,6 +6,15 @@ module Mutant
       # Namespace for define mutations
       class Define < self
 
+        # Mapping from AST node types to their type-aware empty/default values
+        TYPE_TO_DEFAULT = {
+          array: N_EMPTY_ARRAY,
+          hash:  N_EMPTY_HASH,
+          str:   N_EMPTY_STRING,
+          int:   N_ZERO_INTEGER,
+          float: N_ZERO_FLOAT
+        }.freeze
+
       private
 
         def dispatch
@@ -13,12 +22,29 @@ module Mutant
           emit_optarg_body_assignments
           emit_body(N_RAISE)
           emit_body(N_ZSUPER)
+          emit_type_aware_defaults
 
           return if !body || ignore?(body)
 
           emit_body(nil) unless n_begin?(body) && body.children.any?(&method(:ignore?))
 
           emit_body_mutations
+        end
+
+        def emit_type_aware_defaults
+          return unless body
+
+          default_node = TYPE_TO_DEFAULT[return_expression.type]
+
+          emit_body(default_node) if default_node
+        end
+
+        def return_expression
+          if n_begin?(body)
+            body.children.last
+          else
+            body
+          end
         end
 
         def emit_optarg_body_assignments

--- a/ruby/meta/def.rb
+++ b/ruby/meta/def.rb
@@ -237,3 +237,86 @@ Mutant::Meta::Example.add :def, :send do
   mutation 'def foo(...); nil; end'
   mutation 'def foo(...); end'
 end
+
+# Type-aware default return mutations: arrays
+Mutant::Meta::Example.add :def do
+  source 'def foo; [true]; end'
+
+  mutation 'def foo; raise; end'
+  mutation 'def foo; super; end'
+  mutation 'def foo; []; end'
+  mutation 'def foo; end'
+  mutation 'def foo; nil; end'
+  mutation 'def foo; [false]; end'
+  mutation 'def foo; true; end'
+end
+
+# Type-aware default return mutations: hashes
+Mutant::Meta::Example.add :def do
+  source 'def foo; { a: true }; end'
+
+  mutation 'def foo; raise; end'
+  mutation 'def foo; super; end'
+  mutation 'def foo; {}; end'
+  mutation 'def foo; end'
+  mutation 'def foo; nil; end'
+  mutation 'def foo; { a: false }; end'
+  mutation 'def foo; { a__mutant__: true }; end'
+end
+
+# Type-aware default return mutations: strings
+Mutant::Meta::Example.add :def do
+  source 'def foo; "hello"; end'
+
+  mutation 'def foo; raise; end'
+  mutation 'def foo; super; end'
+  mutation 'def foo; ""; end'
+  mutation 'def foo; end'
+  mutation 'def foo; nil; end'
+end
+
+# Type-aware default return mutations: integers
+Mutant::Meta::Example.add :def do
+  source 'def foo; 42; end'
+
+  mutation 'def foo; raise; end'
+  mutation 'def foo; super; end'
+  mutation 'def foo; 0; end'
+  mutation 'def foo; end'
+  mutation 'def foo; nil; end'
+  mutation 'def foo; 1; end'
+  mutation 'def foo; 43; end'
+  mutation 'def foo; 41; end'
+end
+
+# Type-aware default return mutations: floats
+Mutant::Meta::Example.add :def do
+  source 'def foo; 3.14; end'
+
+  mutation 'def foo; raise; end'
+  mutation 'def foo; super; end'
+  mutation 'def foo; 0.0; end'
+  mutation 'def foo; end'
+  mutation 'def foo; nil; end'
+  mutation 'def foo; 0.0 / 0.0; end'
+  mutation 'def foo; 1.0 / 0.0; end'
+  mutation 'def foo; -1.0 / 0.0; end'
+  mutation 'def foo; 1.0; end'
+end
+
+# Type-aware defaults with multi-statement body (last statement determines type)
+Mutant::Meta::Example.add :def do
+  source 'def foo; bar; [true]; end'
+
+  mutation 'def foo; raise; end'
+  mutation 'def foo; super; end'
+  mutation 'def foo; []; end'
+  mutation 'def foo; end'
+  mutation 'def foo; bar; end'
+  mutation 'def foo; [true]; end'
+  mutation 'def foo; nil; [true]; end'
+  mutation 'def foo; bar; nil; end'
+  mutation 'def foo; bar; []; end'
+  mutation 'def foo; bar; [false]; end'
+  mutation 'def foo; bar; true; end'
+end


### PR DESCRIPTION
Extend method body mutations to emit type-appropriate empty/default values based on the inferred return type of the method:

* `Array` → `[]`
* `Hash` → `{}`
* `String` → `""`
* `Integer` → `0`
* `Float` → `0.0`

The return type is inferred from the last expression in the method body.