### PR TITLE
Add inline rescue modifier mutations

### DIFF
--- a/ruby/lib/mutant/mutator/node/rescue.rb
+++ b/ruby/lib/mutant/mutator/node/rescue.rb
@@ -20,6 +20,11 @@ module Mutant
           mutate_body
           mutate_rescue_bodies
           mutate_else_body
+          emit_singletons if standalone?
+        end
+
+        def standalone?
+          parent_type.nil?
         end
 
         def mutate_rescue_bodies
@@ -31,6 +36,16 @@ module Mutant
             end
           end
           emit_rescue_clause_removals
+          emit_handler_promotion
+        end
+
+        def emit_handler_promotion
+          return unless standalone?
+
+          children_indices(RESCUE_INDICES).each do |index|
+            resbody = AST::Meta::Resbody.new(node: children.fetch(index))
+            emit(resbody.body)
+          end
         end
 
         def emit_rescue_clause_removals

--- a/ruby/meta/rescue.rb
+++ b/ruby/meta/rescue.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# Inline rescue modifier - promotes handler body when no captures/assignment
+Mutant::Meta::Example.add :rescue do
+  source 'foo rescue bar'
+
+  singleton_mutations
+
+  # Mutate body to nil
+  mutation 'nil rescue bar'
+
+  # Promote body (remove rescue)
+  mutation 'foo'
+
+  # Mutate handler to nil
+  mutation 'foo rescue nil'
+
+  # Concat body and handler
+  mutation 'foo; bar'
+
+  # Promote handler (use fallback directly)
+  mutation 'bar'
+end
+
 Mutant::Meta::Example.add :rescue do
   source 'begin; rescue ExceptionA, ExceptionB => error; true; end'
 


### PR DESCRIPTION
Add handler promotion mutation for standalone inline rescue expressions (e.g., `foo rescue bar` -> `bar`). The `standalone?` check ensures this only applies when `rescue` has no parent node, which is the case for inline `rescue` modifiers but not for `rescue` inside method bodies or `begin` blocks.