### PR TITLE
Add generic receiver promotion mutations for blocks

### DIFF
--- a/ruby/lib/mutant/mutator/node/block.rb
+++ b/ruby/lib/mutant/mutator/node/block.rb
@@ -14,10 +14,20 @@ module Mutant
         def dispatch
           emit_singletons
           emit(send) unless n_lambda?(send)
+          emit_receiver_promotion
           emit_send_mutations(&method(:valid_send_mutation?))
           emit_arguments_mutations
 
           mutate_body
+        end
+
+        def emit_receiver_promotion
+          return unless n_send?(send)
+
+          send_meta = AST::Meta::Send.new(node: send)
+          return unless send_meta.receiver
+
+          emit(send_meta.receiver)
         end
 
         def mutate_body

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -715,6 +715,7 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'custom.proc'
+  mutation 'custom'             # receiver promotion
   mutation 'custom { }'
   mutation 'self.proc { }'
   mutation 'custom.proc { raise }'
@@ -734,6 +735,7 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'Proc.new'
+  mutation 'Proc'               # receiver promotion
   mutation 'self.new { }'
   mutation 'Proc.new { raise }'
   mutation 'lambda { }'


### PR DESCRIPTION
Mutate `a.b { }` to `a` for any method call with an explicit receiver and block. This tests whether the method call and block actually matter.