### PR TITLE
Add explicit ensure mutator with ensure-clause reduction

### DIFF
--- a/ruby/lib/mutant.rb
+++ b/ruby/lib/mutant.rb
@@ -171,6 +171,7 @@ module Mutant
     require 'mutant/mutator/node/regopt'
     require 'mutant/mutator/node/resbody'
     require 'mutant/mutator/node/rescue'
+    require 'mutant/mutator/node/ensure'
     require 'mutant/mutator/node/match_current_line'
     require 'mutant/mutator/node/index'
     require 'mutant/mutator/node/procarg_zero'

--- a/ruby/lib/mutant/mutator/node/ensure.rb
+++ b/ruby/lib/mutant/mutator/node/ensure.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Mutant
+  class Mutator
+    class Node
+      # Mutator for ensure nodes
+      class Ensure < self
+
+        handle(:ensure)
+
+        children :body, :ensure_body
+
+      private
+
+        def dispatch
+          emit(body) if body
+          emit_body_mutations if body
+          emit_ensure_body_mutations if ensure_body
+        end
+
+      end # Ensure
+    end # Node
+  end # Mutator
+end # Mutant

--- a/ruby/meta/ensure.rb
+++ b/ruby/meta/ensure.rb
@@ -5,4 +5,29 @@ Mutant::Meta::Example.add :ensure do
 
   singleton_mutations
   mutation 'begin; rescue; ensure; false; end'
+  mutation 'begin; rescue; end'
+end
+
+Mutant::Meta::Example.add :ensure do
+  source 'begin; foo; ensure; bar; end'
+
+  singleton_mutations
+  mutation 'begin; nil; ensure; bar; end'
+  mutation 'begin; foo; ensure; nil; end'
+  mutation 'begin; foo; end'
+end
+
+Mutant::Meta::Example.add :ensure do
+  source 'begin; foo; ensure; end'
+
+  singleton_mutations
+  mutation 'begin; nil; ensure; end'
+  mutation 'begin; foo; end'
+end
+
+Mutant::Meta::Example.add :ensure do
+  source 'begin; ensure; bar; end'
+
+  singleton_mutations
+  mutation 'begin; ensure; nil; end'
 end

--- a/ruby/meta/rescue.rb
+++ b/ruby/meta/rescue.rb
@@ -91,6 +91,7 @@ Mutant::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; rescue; ensure; false; end'
+  mutation 'begin; rescue; end'
 end
 
 # Multiple rescue clauses with assignment - test individual clause removal


### PR DESCRIPTION
This PR adds an explicit mutator for `ensure` nodes. This previously relied on generic traversal.

```ruby
begin
  foo
ensure
  bar
end
```

Now includes explicit reduction:

```ruby
begin
  foo
end
```