### PR TITLE
Add literal mutators for complex and rational numeric nodes

### DIFF
--- a/ruby/lib/mutant.rb
+++ b/ruby/lib/mutant.rb
@@ -125,6 +125,8 @@ module Mutant
     require 'mutant/mutator/node/literal/string'
     require 'mutant/mutator/node/literal/integer'
     require 'mutant/mutator/node/literal/float'
+    require 'mutant/mutator/node/literal/rational'
+    require 'mutant/mutator/node/literal/complex'
     require 'mutant/mutator/node/literal/array'
     require 'mutant/mutator/node/literal/hash'
     require 'mutant/mutator/node/literal/regex'

--- a/ruby/lib/mutant/mutator/node/literal/complex.rb
+++ b/ruby/lib/mutant/mutator/node/literal/complex.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Mutant
+  class Mutator
+    class Node
+      class Literal < self
+        # Mutator for complex literals
+        class Complex < self
+
+          ONE = 1i
+
+          handle(:complex)
+
+          children :value
+
+        private
+
+          def dispatch
+            emit_singletons
+            emit_values
+          end
+
+          def values
+            [0i, ONE, value + ONE, value - ONE]
+          end
+
+        end # Complex
+      end # Literal
+    end # Node
+  end # Mutator
+end # Mutant

--- a/ruby/lib/mutant/mutator/node/literal/rational.rb
+++ b/ruby/lib/mutant/mutator/node/literal/rational.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Mutant
+  class Mutator
+    class Node
+      class Literal < self
+        # Mutator for rational literals
+        class Rational < self
+
+          ONE = 1r
+
+          handle(:rational)
+
+          children :value
+
+        private
+
+          def dispatch
+            emit_singletons
+            emit_values
+          end
+
+          def values
+            [0r, ONE, value + ONE, value - ONE]
+          end
+
+        end # Rational
+      end # Literal
+    end # Node
+  end # Mutator
+end # Mutant

--- a/ruby/meta/complex.rb
+++ b/ruby/meta/complex.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Mutant::Meta::Example.add :complex do
+  source '10i'
+
+  singleton_mutations
+
+  mutation '0i'
+  mutation '1i'
+  mutation '11i'
+  mutation '9i'
+end

--- a/ruby/meta/rational.rb
+++ b/ruby/meta/rational.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Mutant::Meta::Example.add :rational do
+  source '10r'
+
+  singleton_mutations
+
+  mutation '0r'
+  mutation '1r'
+  mutation '11r'
+  mutation '9r'
+end


### PR DESCRIPTION
Add explicit mutation support for Ruby `:rational` and `:complex` literal AST nodes.

```ruby
10r
```

Now includes mutations like:

```ruby
nil
0r
1r
9r
11r
```

Ditto for complex numbers.