### PR TITLE
Add any?/none? orthogonal swap mutations

### DIFF
--- a/ruby/lib/mutant/mutation/operators.rb
+++ b/ruby/lib/mutant/mutation/operators.rb
@@ -31,7 +31,7 @@ module Mutant
           :| =>          %i[& ^],
           __send__:      %i[public_send],
           all?:          %i[any?],
-          any?:          %i[all?],
+          any?:          %i[all? none?],
           at:            %i[fetch key?],
           # Bang to non-bang mutations (Array methods)
           capitalize!:   %i[capitalize],
@@ -64,6 +64,7 @@ module Mutant
           method:        %i[public_method],
           min:           %i[first last],
           min_by:        %i[first last],
+          none?:         %i[any?],
           reject!:       %i[reject],
           reverse!:      %i[reverse],
           reverse_each:  %i[each],

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -117,6 +117,16 @@ Mutant::Meta::Example.add :send do
 
   singleton_mutations
   mutation 'all?'
+  mutation 'none?'
+  mutation 'false'
+  mutation 'true'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'none?'
+
+  singleton_mutations
+  mutation 'any?'
   mutation 'false'
   mutation 'true'
 end


### PR DESCRIPTION
This PR adds orthogonal method-swap mutations between `any?` and `none?` in operator mutations.