### PR TITLE
Add append/prepend orthogonal swap mutations

### DIFF
--- a/ruby/lib/mutant/mutation/operators.rb
+++ b/ruby/lib/mutant/mutation/operators.rb
@@ -32,6 +32,7 @@ module Mutant
           __send__:      %i[public_send],
           all?:          %i[any?],
           any?:          %i[all? none?],
+          append:        %i[prepend],
           at:            %i[fetch key?],
           # Bang to non-bang mutations (Array methods)
           capitalize!:   %i[capitalize],
@@ -64,6 +65,8 @@ module Mutant
           max:           %i[first last],
           max_by:        %i[first last],
           merge!:        %i[merge],
+          prepend:       %i[append],
+          push:          %i[unshift],
           method:        %i[public_method],
           min:           %i[first last],
           min_by:        %i[first last],
@@ -100,6 +103,7 @@ module Mutant
           transform_values!: %i[transform_values],
           unicode_normalize!: %i[unicode_normalize],
           uniq!:         %i[uniq],
+          unshift:       %i[push],
           upcase!:       %i[upcase],
           values:        %i[keys],
           values_at:     %i[fetch_values]

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -1629,3 +1629,52 @@ Mutant::Meta::Example.add :send do
   mutation 'foo'
   mutation 'self.reject(&:bar)'
 end
+
+# push/append <-> unshift/prepend orthogonal swap mutations
+Mutant::Meta::Example.add :send do
+  source 'foo.push(bar)'
+
+  singleton_mutations
+  mutation 'foo.unshift(bar)'
+  mutation 'foo.push'
+  mutation 'foo.push(nil)'
+  mutation 'foo'
+  mutation 'bar'
+  mutation 'self.push(bar)'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.unshift(bar)'
+
+  singleton_mutations
+  mutation 'foo.push(bar)'
+  mutation 'foo.unshift'
+  mutation 'foo.unshift(nil)'
+  mutation 'foo'
+  mutation 'bar'
+  mutation 'self.unshift(bar)'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.append(bar)'
+
+  singleton_mutations
+  mutation 'foo.prepend(bar)'
+  mutation 'foo.append'
+  mutation 'foo.append(nil)'
+  mutation 'foo'
+  mutation 'bar'
+  mutation 'self.append(bar)'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.prepend(bar)'
+
+  singleton_mutations
+  mutation 'foo.append(bar)'
+  mutation 'foo.prepend'
+  mutation 'foo.prepend(nil)'
+  mutation 'foo'
+  mutation 'bar'
+  mutation 'self.prepend(bar)'
+end


### PR DESCRIPTION
This PR adds orthogonal method-swap mutations between `append`/`push` and `prepend`/`unshift` in operator mutations.