### PR TITLE
Add zero?/nonzero? orthogonal swap mutations

### DIFF
--- a/ruby/lib/mutant/mutation/operators.rb
+++ b/ruby/lib/mutant/mutation/operators.rb
@@ -106,7 +106,8 @@ module Mutant
           unshift:       %i[push],
           upcase!:       %i[upcase],
           values:        %i[keys],
-          values_at:     %i[fetch_values]
+          values_at:     %i[fetch_values],
+          zero?:         %i[nonzero?]
         }.freeze.tap { |hash| hash.each_value(&:freeze) }
       end
 

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -1678,3 +1678,15 @@ Mutant::Meta::Example.add :send do
   mutation 'bar'
   mutation 'self.prepend(bar)'
 end
+
+# zero? -> nonzero? orthogonal swap mutation
+Mutant::Meta::Example.add :send do
+  source 'foo.zero?'
+
+  singleton_mutations
+  mutation 'foo.nonzero?'
+  mutation 'foo'
+  mutation 'self.zero?'
+  mutation 'false'
+  mutation 'true'
+end


### PR DESCRIPTION
This PR adds orthogonal method-swap mutations between `zero?` and `nonzero?` in operator mutations.