### PR TITLE
Add count/size orthogonal swap mutations

### DIFF
--- a/ruby/lib/mutant/mutation/operators.rb
+++ b/ruby/lib/mutant/mutation/operators.rb
@@ -40,6 +40,7 @@ module Mutant
           chop!:         %i[chop],
           collect!:      %i[collect],
           compact!:      %i[compact],
+          count:         %i[size length],
           delete!:       %i[delete],
           detect:        %i[first last],
           downcase!:     %i[downcase],

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -1690,3 +1690,27 @@ Mutant::Meta::Example.add :send do
   mutation 'false'
   mutation 'true'
 end
+
+# count -> size/length semantic reduction mutations
+Mutant::Meta::Example.add :send do
+  source 'foo.count'
+
+  singleton_mutations
+  mutation 'foo.size'
+  mutation 'foo.length'
+  mutation 'foo'
+  mutation 'self.count'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.count(bar)'
+
+  singleton_mutations
+  mutation 'foo.size(bar)'
+  mutation 'foo.length(bar)'
+  mutation 'foo.count'
+  mutation 'foo.count(nil)'
+  mutation 'foo'
+  mutation 'bar'
+  mutation 'self.count(bar)'
+end


### PR DESCRIPTION
This PR adds orthogonal method-swap mutations between `count` and `size`/`length` in operator mutations.