### PR TITLE
Add keys/values orthogonal swap mutations

### DIFF
--- a/ruby/lib/mutant/mutation/operators.rb
+++ b/ruby/lib/mutant/mutation/operators.rb
@@ -53,6 +53,7 @@ module Mutant
           gsub:          %i[sub],
           gsub!:         %i[gsub],
           is_a?:         %i[instance_of?],
+          keys:          %i[values],
           kind_of?:      %i[instance_of?],
           last:          %i[first],
           lstrip!:       %i[lstrip],
@@ -97,6 +98,7 @@ module Mutant
           unicode_normalize!: %i[unicode_normalize],
           uniq!:         %i[uniq],
           upcase!:       %i[upcase],
+          values:        %i[keys],
           values_at:     %i[fetch_values]
         }.freeze.tap { |hash| hash.each_value(&:freeze) }
       end

--- a/ruby/meta/send.rb
+++ b/ruby/meta/send.rb
@@ -1573,3 +1573,22 @@ Mutant::Meta::Example.add :send do
   mutation 'false'
   mutation 'true'
 end
+
+# keys <-> values orthogonal swap mutations
+Mutant::Meta::Example.add :send do
+  source 'foo.keys'
+
+  singleton_mutations
+  mutation 'foo.values'
+  mutation 'foo'
+  mutation 'self.keys'
+end
+
+Mutant::Meta::Example.add :send do
+  source 'foo.values'
+
+  singleton_mutations
+  mutation 'foo.keys'
+  mutation 'foo'
+  mutation 'self.values'
+end


### PR DESCRIPTION
This PR adds orthogonal method-swap mutations between `keys` and `values` in operator mutations.