### PR TITLE
Fix JSON::GeneratorError on non-UTF-8 log bytes

### DIFF
--- a/ruby/lib/mutant/result/json_writer.rb
+++ b/ruby/lib/mutant/result/json_writer.rb
@@ -24,7 +24,28 @@ module Mutant
     private
 
       def json
-        JSON.generate(Session::JSON.dump(session).from_right)
+        JSON.generate(scrub_encoding(Session::JSON.dump(session).from_right))
+      end
+
+      # Ensure all strings are valid UTF-8 before JSON serialization.
+      #
+      # Strings captured from child process pipes (see Isolation::Fork) arrive
+      # tagged as ASCII-8BIT. The json gem accepts those when the bytes happen
+      # to be valid UTF-8 but raises JSON::GeneratorError otherwise (e.g. when
+      # a multi-byte character split by a read boundary lands as a truncated
+      # sequence). Re-tag as UTF-8 and scrub any genuinely invalid byte
+      # sequences with U+FFFD.
+      def scrub_encoding(object)
+        case object
+        when String
+          object.dup.force_encoding(Encoding::UTF_8).scrub
+        when Hash
+          object.transform_values { |value| scrub_encoding(value) }
+        when Array
+          object.map { |element| scrub_encoding(element) }
+        else
+          object
+        end
       end
 
       def session

--- a/ruby/spec/unit/mutant/result/json_writer_spec.rb
+++ b/ruby/spec/unit/mutant/result/json_writer_spec.rb
@@ -59,4 +59,57 @@ RSpec.describe Mutant::Result::JSONWriter do
       expect(object.call).to be(path)
     end
   end
+
+  describe '#json' do
+    before { allow(process).to receive(:pid).and_return(42) }
+
+    it 'scrubs encoding of the dumped session before JSON generation' do
+      dumped = { 'ruby_version' => "bad\xF7byte".b }
+      allow(Mutant::Result::Session::JSON)
+        .to receive(:dump)
+        .with(instance_of(Mutant::Result::Session))
+        .and_return(Mutant::Either::Right.new(dumped))
+
+      expect(JSON.parse(object.__send__(:json)))
+        .to eql('ruby_version' => "bad\uFFFDbyte")
+    end
+  end
+
+  describe '#scrub_encoding' do
+    def scrub(value)
+      object.__send__(:scrub_encoding, value)
+    end
+
+    it 'retags ASCII-8BIT strings holding valid UTF-8 bytes as UTF-8' do
+      binary = (+'hellö').force_encoding(Encoding::ASCII_8BIT)
+      result = scrub(binary)
+
+      expect(result.encoding).to be(Encoding::UTF_8)
+      expect(result).to eql('hellö')
+    end
+
+    it 'replaces invalid UTF-8 byte sequences with the replacement character' do
+      expect(scrub("bad\xF7byte".b)).to eql("bad\uFFFDbyte")
+    end
+
+    it 'does not mutate frozen strings' do
+      frozen = 'frozen'.b.freeze
+
+      expect { scrub(frozen) }.not_to raise_error
+      expect(frozen.encoding).to be(Encoding::ASCII_8BIT)
+    end
+
+    it 'recurses into hash values' do
+      expect(scrub('key' => "bad\xF7".b)).to eql('key' => "bad\uFFFD")
+    end
+
+    it 'recurses into array elements' do
+      expect(scrub(["bad\xF7".b, 'ok'])).to eql(["bad\uFFFD", 'ok'])
+    end
+
+    it 'leaves non-string scalars untouched' do
+      expect(scrub(42)).to be(42)
+      expect(scrub(nil)).to be(nil)
+    end
+  end
 end


### PR DESCRIPTION
My hacky attempt at fixing https://github.com/mbj/mutant/issues/1609.

@mbj You’ll probably come up with something cleaner but this fixes the problem.