### PR TITLE
Register forward_arg / forward_args in AST structure

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,20 @@
+# Unreleased
+
+* Fix `KeyError` crash in `Mutant::AST::Structure.for` on Ruby's
+  parameter-site argument-forwarding syntax (`def foo(...)` and
+  `def foo(a, ...)`). The `forward_args` and `forward_arg` parser nodes
+  were missing from `Structure::ALL`, so any matcher / subject resolution
+  that descended into such a file crashed. Observed first against
+  `ruby/json` during corpus testing.
+
+  Latent since [#1348](https://github.com/mbj/mutant/pull/1348), which
+  switched `FindMetaclassContaining` (and related traversals) to
+  `Structure.for(type).each_node(...)`. The call-site counterparts
+  (`forwarded_args`, `forwarded_restarg`, `forwarded_kwrestarg`) were
+  registered in [#1402](https://github.com/mbj/mutant/pull/1402) /
+  [#1403](https://github.com/mbj/mutant/pull/1403); the parameter-site
+  leaves were missed.
+
 # v0.16.2 2026-04-20
 
 * Fix `JSON::GeneratorError` crash in `Result::JSONWriter` when test output

--- a/ruby/lib/mutant/ast/structure.rb
+++ b/ruby/lib/mutant/ast/structure.rb
@@ -387,6 +387,16 @@ module Mutant
           variable: nil
         ),
         Node.new(
+          type:     :forward_arg,
+          fixed:    EMPTY_ARRAY,
+          variable: nil
+        ),
+        Node.new(
+          type:     :forward_args,
+          fixed:    EMPTY_ARRAY,
+          variable: nil
+        ),
+        Node.new(
           type:     :forwarded_args,
           fixed:    EMPTY_ARRAY,
           variable: nil

--- a/ruby/meta/forward_arg.rb
+++ b/ruby/meta/forward_arg.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Mutant::Meta::Example.add :forward_arg do
+  source 'def foo(a, ...); bar(a, ...); end'
+
+  mutation 'def foo(a, ...); raise; end'
+  mutation 'def foo(a, ...); super; end'
+  mutation 'def foo(a, ...); end'
+  mutation 'def foo(a, ...); nil; end'
+  mutation 'def foo(a, ...); bar; end'
+  mutation 'def foo(a, ...); bar(nil, ...); end'
+  mutation 'def foo(a, ...); bar(...); end'
+  mutation 'def foo(a, ...); bar(a); end'
+end

--- a/ruby/meta/forward_args.rb
+++ b/ruby/meta/forward_args.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Mutant::Meta::Example.add :forward_args do
+  source 'def foo(...); bar(...); end'
+
+  mutation 'def foo(...); raise; end'
+  mutation 'def foo(...); super; end'
+  mutation 'def foo(...); end'
+  mutation 'def foo(...); nil; end'
+  mutation 'def foo(...); bar; end'
+end


### PR DESCRIPTION
Ruby 2.7+ parameter-site argument forwarding produces leaf nodes `(forward_args)` for `def foo(...)` and `(forward_arg)` for the trailing `...` inside `def foo(a, ...)`. Neither was in `Mutant::AST::Structure::ALL`, so any bootstrap traversal that descended into a file using the syntax crashed with KeyError.

Latent since [#1348](https://github.com/mbj/mutant/pull/1348), which switched FindMetaclassContaining (and related traversals) from a plain node.children walk to `Structure.for(type).each_node(...)` — a strict fetch against Structure::ALL. The call-site counterparts `forwarded_args`, `forwarded_restarg`, `forwarded_kwrestarg` were registered in [#1402](https://github.com/mbj/mutant/pull/1402) and [#1403](https://github.com/mbj/mutant/pull/1403); the parameter-site leaves were missed. Observed first against ruby/json during corpus testing of the test-unit integration.

Covers:
- lib/mutant/ast/structure.rb: two new leaf entries.
- meta/forward_arg.rb, meta/forward_args.rb: mutation-generation examples for both forwarding shapes, following the one-file-per- node-type convention (kwarg.rb, blockarg.rb, ...).
- Changelog: unreleased entry citing #1348 / #1402 / #1403.