### PR TITLE
Fix Rails parallel-worker hook docs for Rails 7.2+ and verify in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,39 @@ jobs:
         cache-version: ${{ hashFiles('ruby/*.gemspec') }}
         working-directory: ./ruby
     - run: ./bin/manager ruby ${{ matrix.execution }}
+  rails-tests:
+    name: Rails Tests (rails ${{ matrix.rails }} / ${{ matrix.database }})
+    needs: rust-build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # One representative Ruby per Rails version (Ruby x Rails compatibility),
+        # each against both databases the hooks isolate. PostgreSQL is provided
+        # on demand by the pg-ephemeral gem via the runner's Docker.
+        include:
+          - { rails: "7.2", ruby: ruby-3.3, database: postgresql }
+          - { rails: "7.2", ruby: ruby-3.3, database: sqlite }
+          - { rails: "8.0", ruby: ruby-3.4, database: postgresql }
+          - { rails: "8.0", ruby: ruby-3.4, database: sqlite }
+          - { rails: "8.1", ruby: ruby-4.0, database: postgresql }
+          - { rails: "8.1", ruby: ruby-4.0, database: sqlite }
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/download-artifact@v8
+      with:
+        name: manager-x86_64-unknown-linux-gnu
+        path: ./bin
+    - run: chmod +x ./bin/manager
+    # libpq headers for building the pg gem.
+    - run: sudo apt-get update && sudo apt-get install -y libpq-dev
+    # Workaround for Bundler 4.x security check on world-writable GHA runner directories.
+    # See: https://github.com/ruby/rubygems/issues/7983
+    - run: mkdir -p /opt/hostedtoolcache/Ruby && chmod -R o-w /opt/hostedtoolcache/Ruby
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    # The manager runs `bundle install` itself with RAILS_VERSION set, then
+    # provisions PostgreSQL (when needed) and runs the verification.
+    - run: ./bin/manager ruby rails-verify --rails ${{ matrix.rails }} --database ${{ matrix.database }}

--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ Mutant is supported on Linux and macOS.
 | 3.4     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 4.0     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
+## Rails
+
+Mutant runs against Rails applications, including parallel-worker database
+isolation (PostgreSQL and SQLite). The hook recipes are verified in CI on every
+non-EOL Rails version:
+
+| Version | Status |
+| ------- | ------ |
+| 7.2     | :heavy_check_mark: |
+| 8.0     | :heavy_check_mark: |
+| 8.1     | :heavy_check_mark: |
+
+See the [Rails Integration guide](/docs/rails.md) for setup, eager loading, and
+per-worker database isolation. A runnable, CI-verified example lives in
+[rails_example](rails_example/).
+
 ## Licensing
 
 **Free for open source.** Use `--usage opensource` for public repositories.

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -2,7 +2,7 @@
 
 Rails applications have specific requirements when running under mutant: the application must be initialized in test mode, all subjects must be loaded eagerly so they are discoverable, and parallel workers need isolated database resources to avoid conflicts.
 
-This document is the canonical reference for setting up mutant against a Rails application. The mechanisms it relies on are documented in:
+This document is the canonical reference for setting up mutant against a Rails application. The hook recipes below are verified on every non-EOL Rails version (currently **7.2, 8.0 and 8.1**) against both PostgreSQL and SQLite by a runnable example app — see [Verified example](#verified-example). The mechanisms it relies on are documented in:
 
 - [Configuration](/docs/configuration.md) — the configuration file format
 - [Hooks](/docs/hooks.md) — the hooks system used for eager loading and resource isolation
@@ -11,7 +11,7 @@ This document is the canonical reference for setting up mutant against a Rails a
 
 ## Minimal Setup
 
-A working Rails configuration needs three things in `.mutant.yml`:
+A working Rails configuration needs three things in `config/mutant.yml`:
 
 ```yml
 ---
@@ -25,7 +25,7 @@ integration:
   name: rspec   # or minitest
 
 hooks:
-  - rails_hooks.rb
+  - config/mutant/hooks.rb
 ```
 
 - `requires: ./config/environment` loads the Rails application.
@@ -45,108 +45,105 @@ Rails relies on autoloading: a constant is only loaded the first time it is refe
 The fix is to eager-load the application after mutant has infected the environment:
 
 ```ruby
-# rails_hooks.rb
 hooks.register(:env_infection_post) do
   Rails.application.eager_load!
 end
 ```
 
-This is the recommended baseline for any Rails project, even when no other hooks are needed. Without it, subject expressions can silently match nothing.
+This is the recommended baseline for any Rails project, even when no other hooks are needed. Without it, subject expressions can silently match nothing. The database-isolation recipes below already include this hook.
 
 See the [hooks reference](/docs/hooks.md#available-hooks) for the full list of hook events.
 
 ## Database Isolation for Parallel Workers (PostgreSQL)
 
-> **PostgreSQL-specific.** The example below uses `PG::Connection`, ActiveRecord's `postgresql_connection`, and the `CREATE DATABASE ... TEMPLATE` clause. The hook structure is portable to other adapters (see [Other Databases](#other-databases) below), but the code as written will not run against MySQL, SQLite, or other engines.
+> **PostgreSQL-specific.** The example below uses the `pg` driver (`PG.connect`, `PG::Connection`) and the `CREATE DATABASE ... TEMPLATE` clause. The hook structure is portable to other adapters (see [Other Databases](#other-databases) below), but the code as written will not run against MySQL, SQLite, or other engines.
 
 When running with multiple workers (the default), each worker shares the same Rails process layout and therefore the same database configuration. Without isolation, workers fight over the same tables and tests become non-deterministic.
 
-The pattern below creates a per-worker copy of the test database using PostgreSQL's `TEMPLATE` clause. Each worker gets its own database (`<test_db>_mutant_worker_<index>`) cloned from the template at process start.
+The recipe below creates a per-worker copy of the test database using PostgreSQL's `TEMPLATE` clause. Each worker gets its own database (`<test_db>_mutant_worker_<index>`) cloned from the template at process start. Save it as `config/mutant/hooks.rb` (the path referenced by `config/mutant.yml`):
 
+<!-- BEGIN config/mutant/hooks_postgresql.rb -->
 ```ruby
-# rails_hooks.rb
+# The abstract base classes whose connection pools need a per-worker database.
+# A single-database app has just ActiveRecord::Base; add each additional
+# abstract base class (e.g. AnalyticsRecord) here if the app connects to more
+# than one database, and the hooks below will isolate each of them per worker.
+#
+# If those base classes use different database engines (e.g. one on PostgreSQL
+# and one on SQLite), merge this recipe with the SQLite one and branch on
+# base.connection_pool.db_config.adapter inside the loop.
+base_records = -> { [ActiveRecord::Base] }
+
+disconnect_pool = ->(base:) { base.connection_pool.disconnect! }
+
+with_root_connection = lambda do |db_config, &block|
+  config     = db_config.configuration_hash
+  connection = PG.connect(
+    host:     config[:host],
+    port:     config[:port],
+    user:     config[:username],
+    password: config[:password],
+    dbname:   'postgres'
+  )
+
+  begin
+    block.call(connection)
+  ensure
+    connection.close
+  end
+end
+
+isolate_database = lambda do |base:, index:|
+  db_config = base.connection_pool.db_config
+  template  = db_config.database
+  isolated  = "#{template}_mutant_worker_#{index}"
+
+  with_root_connection.call(db_config) do |connection|
+    quoted_template = PG::Connection.quote_ident(template)
+    quoted_isolated = PG::Connection.quote_ident(isolated)
+
+    connection.exec("DROP DATABASE IF EXISTS #{quoted_isolated}")
+    connection.exec("CREATE DATABASE #{quoted_isolated} TEMPLATE #{quoted_template}")
+  end
+
+  db_config._database = isolated
+end
+
+isolate_index = lambda do |index:|
+  base_records.call.each do |base|
+    disconnect_pool.call(base:)
+    isolate_database.call(base:, index:)
+  end
+end
+
 hooks.register(:env_infection_post) do
   Rails.application.eager_load!
 end
 
 hooks.register(:setup_integration_post) do
-  base_records.each do |base|
-    disconnect_pool(base:)
-  end
+  base_records.call.each { |base| disconnect_pool.call(base:) }
 end
 
-hooks.register(:test_worker_process_start)     { |index:| isolate_index(index:) }
-hooks.register(:mutation_worker_process_start) { |index:| isolate_index(index:) }
-
-def self.base_records
-  [
-    ActiveRecord::Base,
-  ]
-end
-
-def self.isolate_index(index:)
-  base_records.each do |base|
-    disconnect_pool(base:)
-    isolate_database(base:, index:)
-  end
-end
-
-def self.isolate_database(base:, index:)
-  db_config = base
-    .connection_handler
-    .retrieve_connection_pool(base.connection_specification_name)
-    .db_config
-
-  raw_template_database = db_config.database
-  raw_isolated_database = "#{raw_template_database}_mutant_worker_#{index}"
-
-  with_root_connection do |connection|
-    template_database = PG::Connection.quote_ident(raw_template_database)
-    isolated_database = PG::Connection.quote_ident(raw_isolated_database)
-
-    connection.exec_query("DROP DATABASE IF EXISTS #{isolated_database}")
-    connection.exec_query("CREATE DATABASE #{isolated_database} TEMPLATE #{template_database}")
-  end
-
-  db_config._database = raw_isolated_database
-end
-
-def self.disconnect_pool(base:)
-  base
-    .connection_handler
-    .retrieve_connection_pool(base.connection_specification_name)
-    .disconnect
-end
-
-def self.with_root_connection
-  base = ActiveRecord::Base
-
-  pool = base
-    .connection_handler
-    .retrieve_connection_pool(base.connection_specification_name)
-
-  connection = base
-    .postgresql_connection(**pool.db_config.configuration_hash, database: 'postgres')
-
-  yield connection
-
-  connection.disconnect!
-end
+hooks.register(:test_worker_process_start)     { |index:| isolate_index.call(index:) }
+hooks.register(:mutation_worker_process_start) { |index:| isolate_index.call(index:) }
 ```
+<!-- END config/mutant/hooks_postgresql.rb -->
 
 What this does:
 
 The actual per-worker database setup happens in the *worker-start* hooks. The other two hooks set up preconditions in the parent process.
 
-- **`mutation_worker_process_start`** and **`test_worker_process_start`** — the core of the example. Both registered to the same `isolate_index` body. Each fires once inside a forked worker process: the worker drops the inherited connection, runs `CREATE DATABASE … TEMPLATE`, and rebinds `db_config._database` to the per-worker name. The two hooks fire under different commands — `mutation_worker_process_start` under `mutant run`, `test_worker_process_start` under `mutant test` — so **both registrations are required** if you want isolation in both modes. Drop one and that command's workers will trample each other on the shared template database.
+- **`mutation_worker_process_start`** and **`test_worker_process_start`** — the core of the recipe. Both run `isolate_index`, which fires once inside each forked worker process: for every base class it drops the inherited connection pool, opens a root connection via the raw `pg` driver (`PG.connect` to the `postgres` maintenance database), runs `CREATE DATABASE … TEMPLATE`, and rebinds `db_config._database` to the per-worker name. The two hooks fire under different commands — `mutation_worker_process_start` under `mutant run`, `test_worker_process_start` under `mutant test` — so **both registrations are required** if you want isolation in both modes. Drop one and that command's workers will trample each other on the shared template database.
 - **`setup_integration_post`** — releases the parent's connection to the template database so workers *can* use it as a `TEMPLATE`. PostgreSQL refuses `CREATE DATABASE … TEMPLATE myapp_test` while any session (including the parent's RSpec/Minitest connection opened during integration setup) is connected to `myapp_test`. Without this hook the first worker's `CREATE DATABASE` errors with `source database "myapp_test" is being accessed by other users`. Fires in both `mutant run` and `mutant test`.
 - **`env_infection_post`** — eager-loads the application so subjects are discoverable (see [Recommended Hook: Eager Load](#recommended-hook-eager-load) above). Fires in both `mutant run` and `mutant test`.
+
+`PG.connect` reads its host, port, user and password from the connection's `configuration_hash`, so the same recipe works whether the application is configured with a `DATABASE_URL` or with discrete keys in `config/database.yml`. The root connection targets the `postgres` maintenance database because you cannot `CREATE`/`DROP` a database while connected to it.
 
 The `mutant test` case is worth calling out explicitly: this same hook file lets you run `mutant test` as a drop-in parallel test runner (no mutations), with the same per-worker database isolation — provided you registered `test_worker_process_start`. See [Test Runner](/docs/test-runner.md) for that workflow.
 
 ## Database Isolation for Parallel Workers (SQLite)
 
-> **SQLite-specific.** SQLite database files should not be shared by parallel workers. The example below uses a test database file prepared before mutant starts, then copies that file for each worker process.
+> **SQLite-specific.** SQLite database files should not be shared by parallel workers. The recipe below uses a test database file prepared before mutant starts, then copies that file for each worker process.
 
 Run the Rails test database preparation step before starting mutant:
 
@@ -154,65 +151,72 @@ Run the Rails test database preparation step before starting mutant:
 RAILS_ENV=test bin/rails db:test:prepare
 ```
 
-Then configure a hook file that copies the prepared database for every worker:
+Then save the following as `config/mutant/hooks.rb`. It copies the prepared database for every worker:
 
+<!-- BEGIN config/mutant/hooks_sqlite.rb -->
 ```ruby
-# rails_hooks.rb
-require 'fileutils'
+# The abstract base classes whose databases need a per-worker copy.
+# A single-database app has just ActiveRecord::Base; add each additional
+# abstract base class (e.g. AnalyticsRecord) here if the app connects to more
+# than one database, and the hooks below will isolate each of them per worker.
+#
+# If those base classes use different database engines (e.g. one on SQLite and
+# one on PostgreSQL), merge this recipe with the PostgreSQL one and branch on
+# base.connection_pool.db_config.adapter inside the loop.
+base_records = -> { [ActiveRecord::Base] }
+
+worker_database_dir = File.join(Dir.pwd, 'tmp/mutant')
+
+disconnect_pool = ->(base:) { base.connection_pool.disconnect! }
+
+isolate_database = lambda do |base:, index:|
+  connection_config = base.connection_pool.db_config.configuration_hash
+  template          = connection_config.fetch(:database)
+
+  unless File.file?(template)
+    raise "Missing #{template}; run bin/rails db:test:prepare before mutant"
+  end
+
+  FileUtils.mkdir_p(worker_database_dir)
+
+  name     = File.basename(template, '.*')
+  isolated = File.join(worker_database_dir, "#{name}_mutant_worker_#{index}.sqlite3")
+  FileUtils.cp(template, isolated)
+
+  base.establish_connection(connection_config.merge(database: isolated))
+end
+
+isolate_index = lambda do |index:|
+  base_records.call.each do |base|
+    disconnect_pool.call(base:)
+    isolate_database.call(base:, index:)
+  end
+end
 
 hooks.register(:env_infection_post) do
   Rails.application.eager_load!
 end
 
-project_root = File.expand_path('.', __dir__)
-template_database = File.join(project_root, 'storage/test.sqlite3')
-worker_database_dir = File.join(project_root, 'tmp/mutant')
-
-disconnect_database = lambda do
-  next unless defined?(ActiveRecord::Base)
-  next unless ActiveRecord::Base.connected?
-
-  ActiveRecord::Base.connection_pool.disconnect!
-end
-
-isolate_database = lambda do |index:|
-  connection_config = ActiveRecord::Base.connection_db_config.configuration_hash
-
-  disconnect_database.call
-
-  unless File.file?(template_database)
-    raise "Missing #{template_database}; run bin/rails db:test:prepare before mutant"
-  end
-
-  FileUtils.mkdir_p(worker_database_dir)
-
-  database = File.join(worker_database_dir, "worker-#{index}-#{Process.pid}.sqlite3")
-  FileUtils.cp(template_database, database)
-
-  ENV['DATABASE_URL'] = "sqlite3:#{database}"
-  ActiveRecord::Base.establish_connection(connection_config.merge(database: database))
-end
-
 hooks.register(:setup_integration_post) do
-  disconnect_database.call
+  base_records.call.each { |base| disconnect_pool.call(base:) }
 end
 
-hooks.register(:test_worker_process_start) do |index:|
-  isolate_database.call(index: index)
-end
-
-hooks.register(:mutation_worker_process_start) do |index:|
-  isolate_database.call(index: index)
-end
+hooks.register(:test_worker_process_start)     { |index:| isolate_index.call(index:) }
+hooks.register(:mutation_worker_process_start) { |index:| isolate_index.call(index:) }
 ```
+<!-- END config/mutant/hooks_sqlite.rb -->
 
 What this does:
 
 - **`env_infection_post`** — eager-loads the application so subjects are discoverable.
 - **`setup_integration_post`** — disconnects the parent process from the template database after the test integration has loaded.
-- **`test_worker_process_start`** and **`mutation_worker_process_start`** — copy the prepared SQLite database file, then reconnect Active Record to the worker-specific copy. Both registrations are required if you use both `mutant test` and `mutant run`.
+- **`test_worker_process_start`** and **`mutation_worker_process_start`** — run `isolate_index`, which for every base class copies the prepared SQLite file to a worker-specific path under `tmp/mutant`, then reconnects Active Record to the copy. Both registrations are required if you use both `mutant test` and `mutant run`.
 
-This pattern assumes the hook file lives at the Rails root and the test database lives at `storage/test.sqlite3`. Adjust `project_root` and `template_database` if your application uses different paths. Applications with multiple SQLite databases need to copy and reconnect each database separately.
+This recipe assumes the test database lives at the path Active Record reports for each base class (`bin/rails db:test:prepare` writes it there). Applications with multiple SQLite databases list each abstract base class in `base_records`; every one is copied and reconnected separately.
+
+## Verified example
+
+A complete, runnable version of this setup lives in [`rails_example/`](/rails_example) at the repository root: a minimal Rails app, the two hook recipes above (`config/mutant/hooks_postgresql.rb` and `config/mutant/hooks_sqlite.rb`), and a single `Gemfile` parameterized by `RAILS_VERSION`. CI runs it for Rails 7.2, 8.0 and 8.1 against both databases via `manager ruby rails-verify` (PostgreSQL is provisioned on demand by the [`pg-ephemeral`](https://rubygems.org/gems/pg-ephemeral) gem). The fenced recipes above are kept byte-identical to those files by a guard spec, so what you copy from here is exactly what is tested.
 
 ## Other Databases
 

--- a/manager/src/ruby.rs
+++ b/manager/src/ruby.rs
@@ -241,6 +241,55 @@ pub enum Command {
     },
     /// Verify quick_start example works correctly
     QuickStartVerify,
+    /// Verify the rails_example hooks under a Rails version and database
+    RailsVerify {
+        /// Rails version under test
+        #[arg(long)]
+        rails: RailsVersion,
+        /// Database the hooks isolate
+        #[arg(long)]
+        database: Database,
+    },
+    /// Run the rails_example verification steps against an already-provisioned
+    /// database (internal: re-invoked under `pg-ephemeral run-env`).
+    RailsVerifySteps,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum RailsVersion {
+    #[value(name = "7.2")]
+    V72,
+    #[value(name = "8.0")]
+    V80,
+    #[value(name = "8.1")]
+    V81,
+}
+
+impl RailsVersion {
+    // Gem requirement passed to the rails_example Gemfile via RAILS_VERSION.
+    fn requirement(self) -> &'static str {
+        match self {
+            Self::V72 => "~> 7.2.0",
+            Self::V80 => "~> 8.0.0",
+            Self::V81 => "~> 8.1.0",
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum Database {
+    Postgresql,
+    Sqlite,
+}
+
+impl Database {
+    // Value of DB_ADAPTER, read by config/database.yml and config/mutant/hooks.rb.
+    fn adapter(self) -> &'static str {
+        match self {
+            Self::Postgresql => "postgresql",
+            Self::Sqlite => "sqlite3",
+        }
+    }
 }
 
 pub mod rspec {
@@ -320,6 +369,8 @@ impl Runtime {
     pub fn run(self, command: Command, rerun_config: RerunConfig) -> RunResult {
         match command {
             Command::QuickStartVerify => self.run_quick_start_verify(),
+            Command::RailsVerify { rails, database } => Self::run_rails_verify(rails, database),
+            Command::RailsVerifySteps => Self::run_rails_verify_steps(&[]),
             _ => match self {
                 Self::Host => self.run_host(command, rerun_config),
                 Self::Ruby33 => self.run_container("docker.io/library/ruby:3.3-alpine", command),
@@ -394,6 +445,160 @@ impl Runtime {
 
         let mut child = command.spawn().expect("Failed to spawn process");
         child.wait().expect("Failed to wait for process")
+    }
+
+    // Verify the documented Rails hooks (docs/rails.md, mirrored in
+    // rails_example/config/mutant/hooks_*.rb) actually isolate parallel workers
+    // for a given Rails version and database. PostgreSQL gets an ephemeral
+    // server via the pg-ephemeral gem's `run-env`; SQLite needs nothing extra.
+    fn run_rails_verify(rails: RailsVersion, database: Database) -> RunResult {
+        // Run everything from inside the example app. The PostgreSQL path
+        // re-invokes this manager under `pg-ephemeral host run-env`, and that
+        // child inherits this working directory, so both parent and child agree
+        // on where the app lives (see rails_command).
+        std::env::set_current_dir("rails_example")
+            .expect("Failed to change into rails_example directory");
+
+        let base_env = vec![
+            ("RAILS_VERSION".to_string(), rails.requirement().to_string()),
+            ("DB_ADAPTER".to_string(), database.adapter().to_string()),
+            ("RAILS_ENV".to_string(), "test".to_string()),
+        ];
+
+        log::info!(
+            "RailsVerify: bundle install (rails {})",
+            rails.requirement()
+        );
+        if !Self::rails_command(&base_env, &["bundle", "install"]).success() {
+            eprintln!("RailsVerify FAILED: bundle install failed");
+            return RunResult::Failure;
+        }
+
+        match database {
+            Database::Sqlite => Self::run_rails_verify_steps(&base_env),
+            Database::Postgresql => Self::run_rails_verify_postgresql(&base_env),
+        }
+    }
+
+    // `pg-ephemeral host run-env` boots a throwaway PostgreSQL and runs a single
+    // host command with PG*/DATABASE_URL pointing at the container's published
+    // port. The whole verification (schema load + two mutant runs) must share
+    // one server, so we re-invoke this manager under run-env via the
+    // `rails-verify-steps` subcommand; every child it spawns inherits the PG*
+    // variables.
+    fn run_rails_verify_postgresql(base_env: &[(String, String)]) -> RunResult {
+        let manager = std::env::current_exe()
+            .expect("Failed to determine manager executable path")
+            .into_os_string()
+            .into_string()
+            .expect("Manager executable path is not valid UTF-8");
+
+        let status = Self::rails_command(
+            base_env,
+            &[
+                "bundle",
+                "exec",
+                "pg-ephemeral",
+                "host",
+                "run-env",
+                "--",
+                &manager,
+                "ruby",
+                "rails-verify-steps",
+            ],
+        );
+
+        if status.success() {
+            RunResult::Success
+        } else {
+            RunResult::Failure
+        }
+    }
+
+    // Prepare the test database, then run mutant twice: once expecting the
+    // boundary mutation to survive (no covering spec), once expecting 100%
+    // coverage with it. Uses --jobs 2 so the worker-isolation hooks fork.
+    fn run_rails_verify_steps(extra_env: &[(String, String)]) -> RunResult {
+        let mut env = extra_env.to_vec();
+
+        // `pg-ephemeral host run-env` exports a DATABASE_URL pointing at the
+        // server's maintenance database. Point the app at a dedicated
+        // `rails_example_test` instead, so the parallel-worker hooks have a
+        // template database to clone. SQLite runs set no DATABASE_URL.
+        if let Ok(url) = std::env::var("DATABASE_URL") {
+            env.push((
+                "DATABASE_URL".to_string(),
+                Self::url_with_database(&url, "rails_example_test"),
+            ));
+        }
+        let env = env.as_slice();
+
+        log::info!("RailsVerify: preparing test database");
+        if !Self::rails_command(env, &["bundle", "exec", "rails", "db:test:prepare"]).success() {
+            eprintln!("RailsVerify FAILED: db:test:prepare failed");
+            return RunResult::Failure;
+        }
+
+        let mutant = &[
+            "bundle",
+            "exec",
+            "mutant",
+            "run",
+            "--jobs",
+            "2",
+            "User#adult?",
+        ];
+
+        log::info!("RailsVerify: running without covering spec (expecting survivors)");
+        if Self::rails_command(env, mutant).success() {
+            eprintln!("RailsVerify FAILED: expected surviving mutations without covering spec");
+            return RunResult::Failure;
+        }
+        log::info!("RailsVerify: mutation survived as expected");
+
+        log::info!("RailsVerify: running with covering spec (expecting 100% coverage)");
+        let mut covering_env = env.to_vec();
+        covering_env.push(("WITH_COVERING_SPEC".to_string(), "1".to_string()));
+        if !Self::rails_command(&covering_env, mutant).success() {
+            eprintln!("RailsVerify FAILED: expected 100% coverage with covering spec");
+            return RunResult::Failure;
+        }
+        log::info!("RailsVerify: 100% coverage achieved as expected");
+
+        RunResult::Success
+    }
+
+    // Runs in the current working directory, which is the rails_example app:
+    // run_rails_verify chdir's into it, and the run-env child inherits that cwd.
+    fn rails_command(env: &[(String, String)], args: &[&str]) -> process::ExitStatus {
+        let mut command = process::Command::new(args[0]);
+        command.args(&args[1..]);
+
+        for (name, value) in env {
+            command.env(name, value);
+        }
+
+        command
+            .spawn()
+            .expect("Failed to spawn process")
+            .wait()
+            .expect("Failed to wait for process")
+    }
+
+    // Replace the database name (the path segment after the last '/', before any
+    // query string) in a `scheme://user:pass@host:port/database[?query]` URL.
+    fn url_with_database(url: &str, database: &str) -> String {
+        let (base, query) = match url.split_once('?') {
+            Some((base, query)) => (base, Some(query)),
+            None => (url, None),
+        };
+
+        let prefix = base.rsplit_once('/').map_or(base, |(prefix, _)| prefix);
+
+        match query {
+            Some(query) => format!("{prefix}/{database}?{query}"),
+            None => format!("{prefix}/{database}"),
+        }
     }
 
     fn run_host(self, command: Command, rerun_config: RerunConfig) -> RunResult {
@@ -552,6 +757,12 @@ impl Runtime {
             }
             Command::QuickStartVerify => {
                 unreachable!("QuickStartVerify is handled separately in run()")
+            }
+            Command::RailsVerify { .. } => {
+                unreachable!("RailsVerify is handled separately in run()")
+            }
+            Command::RailsVerifySteps => {
+                unreachable!("RailsVerifySteps is handled separately in run()")
             }
         }
     }

--- a/rails_example/.gitignore
+++ b/rails_example/.gitignore
@@ -1,0 +1,6 @@
+/.mutant
+/log
+/storage
+/tmp
+/Gemfile.lock
+*.sqlite3

--- a/rails_example/.rspec
+++ b/rails_example/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/rails_example/Gemfile
+++ b/rails_example/Gemfile
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# The Rails version under test is selected by RAILS_VERSION so a single Gemfile
+# covers every non-EOL Rails version the hooks are verified against. There is no
+# default on purpose: the CI matrix is the single source of truth for the
+# version and must set RAILS_VERSION.
+gem 'rails', ENV.fetch('RAILS_VERSION')
+
+gem 'pg'
+gem 'sqlite3'
+
+# Provides a throwaway PostgreSQL server for the parallel-worker verification
+# via `pg-ephemeral run-env`; backed by Docker/Podman.
+gem 'pg-ephemeral'
+
+gem 'rspec'
+gem 'rspec-rails'
+
+gem 'mutant',       path: '../ruby'
+gem 'mutant-rspec', path: '../ruby'

--- a/rails_example/Rakefile
+++ b/rails_example/Rakefile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative 'config/application'
+
+RailsExample::Application.load_tasks

--- a/rails_example/app/models/application_record.rb
+++ b/rails_example/app/models/application_record.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/rails_example/app/models/user.rb
+++ b/rails_example/app/models/user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  def adult?
+    age >= 18
+  end
+end

--- a/rails_example/bin/rails
+++ b/rails_example/bin/rails
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path('../config/application', __dir__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/rails_example/config/application.rb
+++ b/rails_example/config/application.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative 'boot'
+
+require 'rails'
+require 'active_record/railtie'
+
+Bundler.require(*Rails.groups)
+
+module RailsExample
+  # Minimal Rails application used to verify the mutant Rails hook recipes
+  # documented in docs/rails.md against every non-EOL Rails version.
+  class Application < Rails::Application
+    # Track whatever Rails version is actually loaded for this gemfile, so the
+    # same app boots unchanged on 7.2, 8.0 and 8.1.
+    config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}".to_f)
+
+    config.eager_load = true
+    config.secret_key_base = 'rails_example_secret_key_base'
+
+    # Configurable on Rails < 8.1; removed (always-on) from 8.1 onward. The same
+    # source boots every non-EOL Rails version, so guard rather than drop it.
+    if Rails.gem_version < Gem::Version.new('8.1')
+      config.active_support.to_time_preserves_timezone = :zone
+    end
+  end
+end

--- a/rails_example/config/boot.rb
+++ b/rails_example/config/boot.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'

--- a/rails_example/config/database.yml
+++ b/rails_example/config/database.yml
@@ -1,0 +1,18 @@
+# Test-only database configuration for the mutant Rails example.
+#
+# The adapter is selected by the DB_ADAPTER environment variable so the same
+# application can be verified against both SQLite (default) and PostgreSQL.
+<% adapter = ENV.fetch('DB_ADAPTER', 'sqlite3') %>
+test:
+<% if adapter == 'postgresql' %>
+  # The full connection comes from DATABASE_URL. The manager points it at a
+  # dedicated `rails_example_test` database (rewriting the dbname from the
+  # ephemeral server's maintenance database) so the parallel-worker hooks have a
+  # template database to clone.
+  url: <%= ENV.fetch('DATABASE_URL') %>
+<% else %>
+  adapter: sqlite3
+  database: storage/test.sqlite3
+  pool: 5
+  timeout: 5000
+<% end %>

--- a/rails_example/config/environment.rb
+++ b/rails_example/config/environment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative 'application'
+
+RailsExample::Application.initialize!

--- a/rails_example/config/environments/test.rb
+++ b/rails_example/config/environments/test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.eager_load = true
+  config.consider_all_requests_local = true
+  config.active_support.deprecation = :stderr
+end

--- a/rails_example/config/mutant.yml
+++ b/rails_example/config/mutant.yml
@@ -1,0 +1,14 @@
+---
+usage: opensource
+
+requires:
+  - ./config/environment
+
+environment_variables:
+  RAILS_ENV: test
+
+integration:
+  name: rspec
+
+hooks:
+  - config/mutant/hooks.rb

--- a/rails_example/config/mutant/hooks.rb
+++ b/rails_example/config/mutant/hooks.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Example-only dispatcher.
+#
+# This example app verifies BOTH documented database-isolation recipes from a
+# single Rails application. A real project would simply point config/mutant.yml
+# at one recipe file directly; here we select the one matching the database
+# under verification (DB_ADAPTER, the same variable config/database.yml reads).
+#
+# We `eval` the recipe in this binding rather than `require` it because mutant
+# loads each hook file with the `hooks` builder as a local variable
+# (see Mutant::Hooks.load_pathname); a required file would not see `hooks`.
+#
+# hooks_postgresql.rb and hooks_sqlite.rb are kept byte-identical to the
+# snippets in docs/rails.md by spec/unit/mutant/rails_docs_hooks_spec.rb.
+recipe =
+  case ENV.fetch('DB_ADAPTER', 'sqlite3')
+  when 'postgresql' then 'hooks_postgresql.rb'
+  else 'hooks_sqlite.rb'
+  end
+
+path = File.join(Dir.pwd, 'config', 'mutant', recipe)
+
+eval(File.read(path), binding, path) # rubocop:disable Security/Eval

--- a/rails_example/config/mutant/hooks_postgresql.rb
+++ b/rails_example/config/mutant/hooks_postgresql.rb
@@ -1,0 +1,62 @@
+# The abstract base classes whose connection pools need a per-worker database.
+# A single-database app has just ActiveRecord::Base; add each additional
+# abstract base class (e.g. AnalyticsRecord) here if the app connects to more
+# than one database, and the hooks below will isolate each of them per worker.
+#
+# If those base classes use different database engines (e.g. one on PostgreSQL
+# and one on SQLite), merge this recipe with the SQLite one and branch on
+# base.connection_pool.db_config.adapter inside the loop.
+base_records = -> { [ActiveRecord::Base] }
+
+disconnect_pool = ->(base:) { base.connection_pool.disconnect! }
+
+with_root_connection = lambda do |db_config, &block|
+  config     = db_config.configuration_hash
+  connection = PG.connect(
+    host:     config[:host],
+    port:     config[:port],
+    user:     config[:username],
+    password: config[:password],
+    dbname:   'postgres'
+  )
+
+  begin
+    block.call(connection)
+  ensure
+    connection.close
+  end
+end
+
+isolate_database = lambda do |base:, index:|
+  db_config = base.connection_pool.db_config
+  template  = db_config.database
+  isolated  = "#{template}_mutant_worker_#{index}"
+
+  with_root_connection.call(db_config) do |connection|
+    quoted_template = PG::Connection.quote_ident(template)
+    quoted_isolated = PG::Connection.quote_ident(isolated)
+
+    connection.exec("DROP DATABASE IF EXISTS #{quoted_isolated}")
+    connection.exec("CREATE DATABASE #{quoted_isolated} TEMPLATE #{quoted_template}")
+  end
+
+  db_config._database = isolated
+end
+
+isolate_index = lambda do |index:|
+  base_records.call.each do |base|
+    disconnect_pool.call(base:)
+    isolate_database.call(base:, index:)
+  end
+end
+
+hooks.register(:env_infection_post) do
+  Rails.application.eager_load!
+end
+
+hooks.register(:setup_integration_post) do
+  base_records.call.each { |base| disconnect_pool.call(base:) }
+end
+
+hooks.register(:test_worker_process_start)     { |index:| isolate_index.call(index:) }
+hooks.register(:mutation_worker_process_start) { |index:| isolate_index.call(index:) }

--- a/rails_example/config/mutant/hooks_sqlite.rb
+++ b/rails_example/config/mutant/hooks_sqlite.rb
@@ -1,0 +1,48 @@
+# The abstract base classes whose databases need a per-worker copy.
+# A single-database app has just ActiveRecord::Base; add each additional
+# abstract base class (e.g. AnalyticsRecord) here if the app connects to more
+# than one database, and the hooks below will isolate each of them per worker.
+#
+# If those base classes use different database engines (e.g. one on SQLite and
+# one on PostgreSQL), merge this recipe with the PostgreSQL one and branch on
+# base.connection_pool.db_config.adapter inside the loop.
+base_records = -> { [ActiveRecord::Base] }
+
+worker_database_dir = File.join(Dir.pwd, 'tmp/mutant')
+
+disconnect_pool = ->(base:) { base.connection_pool.disconnect! }
+
+isolate_database = lambda do |base:, index:|
+  connection_config = base.connection_pool.db_config.configuration_hash
+  template          = connection_config.fetch(:database)
+
+  unless File.file?(template)
+    raise "Missing #{template}; run bin/rails db:test:prepare before mutant"
+  end
+
+  FileUtils.mkdir_p(worker_database_dir)
+
+  name     = File.basename(template, '.*')
+  isolated = File.join(worker_database_dir, "#{name}_mutant_worker_#{index}.sqlite3")
+  FileUtils.cp(template, isolated)
+
+  base.establish_connection(connection_config.merge(database: isolated))
+end
+
+isolate_index = lambda do |index:|
+  base_records.call.each do |base|
+    disconnect_pool.call(base:)
+    isolate_database.call(base:, index:)
+  end
+end
+
+hooks.register(:env_infection_post) do
+  Rails.application.eager_load!
+end
+
+hooks.register(:setup_integration_post) do
+  base_records.call.each { |base| disconnect_pool.call(base:) }
+end
+
+hooks.register(:test_worker_process_start)     { |index:| isolate_index.call(index:) }
+hooks.register(:mutation_worker_process_start) { |index:| isolate_index.call(index:) }

--- a/rails_example/db/schema.rb
+++ b/rails_example/db/schema.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ActiveRecord::Schema.define(version: 1) do
+  create_table :users, force: true do |t|
+    t.integer :age, null: false
+  end
+end

--- a/rails_example/spec/spec_helper.rb
+++ b/rails_example/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+ENV['RAILS_ENV'] ||= 'test'
+
+require_relative '../config/environment'
+
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = :expect }
+end

--- a/rails_example/spec/user_spec.rb
+++ b/rails_example/spec/user_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe User do
+  def adult?(age)
+    User.find(User.create!(age:).id).adult?
+  end
+
+  it 'is not an adult below 18' do
+    expect(adult?(17)).to be(false)
+  end
+
+  it 'is an adult above 18' do
+    expect(adult?(21)).to be(true)
+  end
+
+  # The covering example is only loaded when WITH_COVERING_SPEC is set, so the
+  # verify run can demonstrate both a surviving mutation (without it) and 100%
+  # coverage (with it) against a real, persisted record.
+  if ENV['WITH_COVERING_SPEC']
+    it 'is an adult exactly at 18' do
+      expect(adult?(18)).to be(true)
+    end
+  end
+end

--- a/ruby/spec/unit/mutant/rails_docs_hooks_spec.rb
+++ b/ruby/spec/unit/mutant/rails_docs_hooks_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Guards against docs/rails.md drifting from the hook recipes that are actually
+# verified against real Rails by the manager's `rails-verify` command. Each
+# marked ```ruby block in the docs must be byte-identical to its source file.
+RSpec.describe 'docs/rails.md hook recipes', mutant: false do
+  root = File.expand_path('../../../..', __dir__)
+
+  recipes = {
+    'config/mutant/hooks_postgresql.rb' => 'rails_example/config/mutant/hooks_postgresql.rb',
+    'config/mutant/hooks_sqlite.rb'     => 'rails_example/config/mutant/hooks_sqlite.rb'
+  }
+
+  recipes.each do |label, relative_path|
+    it "keeps the #{label} snippet identical to #{relative_path}" do
+      doc = File.read(File.join(root, 'docs/rails.md'))
+
+      pattern = /
+        ^<!--\ BEGIN\ #{Regexp.escape(label)}\ -->\n
+        ```ruby\n
+        (.*?)\n
+        ```\n
+        <!--\ END\ #{Regexp.escape(label)}\ -->$
+      /mx
+
+      match = doc.match(pattern)
+
+      expect(match).not_to(
+        be_nil,
+        "docs/rails.md is missing the marked code block for #{label}"
+      )
+
+      documented = "#{match[1]}\n"
+      source     = File.read(File.join(root, relative_path))
+
+      expect(documented).to eq(source)
+    end
+  end
+end


### PR DESCRIPTION
The PostgreSQL database-isolation example in docs/rails.md used ActiveRecord::Base.postgresql_connection, an adapter-specific factory removed in Rails 7.2, plus connection.exec_query — so the documented recipe crashed on every non-EOL Rails version.

Rather than patch the snippet blind, add an executable example verified in CI, so the docs cannot silently rot again:

- rails_example/: a minimal Rails app exercising both documented hook recipes (config/mutant/hooks_postgresql.rb, config/mutant/hooks_sqlite.rb) through a single RAILS_VERSION-parameterized Gemfile.
- Fixed PostgreSQL recipe: PG.connect / PG::Connection#exec instead of the removed postgresql_connection / exec_query, and base.connection_pool instead of the fragile connection-handler chain.
- manager `rails-verify` subcommand: runs `mutant run --jobs 2` (so the worker-isolation hooks actually fork) against both databases, asserting a surviving mutation without the covering spec and 100% coverage with it. PostgreSQL is provisioned on demand by the pg-ephemeral gem's `host run-env`.
- CI rails-tests job: Rails 7.2, 8.0 and 8.1 x {postgresql, sqlite}.
- Doc-sync guard spec: keeps the fenced blocks in docs/rails.md byte-identical to the verified hook files.

Closes #1631