### PR TITLE
Flush the session file on every alive mutation

### DIFF
--- a/ruby/lib/mutant/mutation/runner/sink.rb
+++ b/ruby/lib/mutant/mutation/runner/sink.rb
@@ -8,12 +8,16 @@ module Mutant
 
         include Anima.new(:env)
 
+        # Minimum seconds between two session flushes
+        FLUSH_INTERVAL = 1.0
+
         # Initialize object
         #
         # @return [undefined]
         def initialize(*)
           super
           @start           = env.world.timer.now
+          @last_flush_at   = @start - FLUSH_INTERVAL
           @subject_results = {}
         end
 
@@ -48,10 +52,11 @@ module Mutant
           mutation        = env.mutations.fetch(response.result.mutation_index)
           subject         = mutation.subject
           mutation_result = mutation_result(mutation, response.result)
+          coverage        = coverage_result(mutation_result)
 
           @subject_results[subject] = Result::Subject.new(
             amount_mutations:  subject.mutations.length,
-            coverage_results:  previous_coverage_results(subject).dup << coverage_result(mutation_result),
+            coverage_results:  previous_coverage_results(subject).dup << coverage,
             expression_syntax: subject.expression.syntax,
             identification:    subject.identification,
             node:              subject.node,
@@ -60,12 +65,33 @@ module Mutant
             tests:             env.selections.fetch(subject)
           )
 
+          flush_session unless coverage.success?
+
           self
         end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
 
       private
+
+        # Persist the session on alive mutations, so survivors are
+        # inspectable while a long run is still going, rather than only
+        # after its final write.
+        #
+        # Alive mutations can arrive far faster than once per second, and
+        # each flush serializes the whole result tree on the main process,
+        # so flushes are rate limited against the monotonic timer. A
+        # survivor that lands inside the suppressed window is picked up by
+        # the next flush, or by the final write in the runner.
+        def flush_session
+          now = env.world.timer.now
+
+          return if (now - @last_flush_at) < FLUSH_INTERVAL
+
+          @last_flush_at = now
+
+          Result::JSONWriter.new(env:, result: status).call
+        end
 
         def coverage_result(mutation_result)
           Result::Coverage.new(

--- a/ruby/lib/mutant/result/json_writer.rb
+++ b/ruby/lib/mutant/result/json_writer.rb
@@ -10,13 +10,19 @@ module Mutant
 
       # Write result JSON file
       #
+      # Written to a temporary file first and renamed into place, so a
+      # concurrent reader of the session file never observes a partial
+      # document. This matters once the file is rewritten during a run.
+      #
       # @return [Pathname]
       def call
         dir = env.world.pathname.new(RESULTS_DIR)
         dir.mkpath
 
         path = dir.join("#{SESSION_ID}.json")
-        path.write(json)
+        tmp_path = dir.join("#{SESSION_ID}.json.tmp")
+        tmp_path.write(json)
+        tmp_path.rename(path)
 
         path
       end

--- a/ruby/spec/support/corpus.rb
+++ b/ruby/spec/support/corpus.rb
@@ -224,6 +224,7 @@ module MutantSpec
       def install_mutant
         return if noinstall?
         relative = ROOT.relative_path_from(repo_path)
+        remove_mutant_gemfile_sources
         repo_path.join('Gemfile').open('a') do |file|
           file << "gem 'mutant', path: '#{relative}'\n"
           file << "gem 'mutant-rspec', path: '#{relative}'\n"
@@ -235,6 +236,17 @@ module MutantSpec
         lockfile = repo_path.join('Gemfile.lock')
         lockfile.delete if lockfile.exist?
         system(%w[bundle])
+      end
+
+      # Remove mutant gem declarations the corpus repository carries itself,
+      # as auom does while mutant-test-unit is unreleased. Bundler refuses
+      # the same gem from two sources, so only the path sources appended
+      # above may remain.
+      def remove_mutant_gemfile_sources
+        gemfile = repo_path.join('Gemfile')
+        content = gemfile.read
+        modified = content.gsub(/^gem ['"]mutant.*\n/, '')
+        gemfile.write(modified) if content != modified
       end
 
       def remove_mutant_gemspec_constraints

--- a/ruby/spec/unit/mutant/mutation/runner/sink_spec.rb
+++ b/ruby/spec/unit/mutant/mutation/runner/sink_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe Mutant::Mutation::Runner::Sink do
 
   let(:object) { described_class.new(env:) }
 
+  let(:writer) do
+    instance_double(Mutant::Result::JSONWriter, call: instance_double(Pathname))
+  end
+
+  before do
+    allow(Mutant::Result::JSONWriter).to receive(:new).and_return(writer)
+  end
+
   describe '#response' do
     subject { object.response(mutation_a_index_response) }
 
@@ -60,6 +68,63 @@ RSpec.describe Mutant::Mutation::Runner::Sink do
 
       it 're-raises the error' do
         expect { subject }.to raise_error(EOFError)
+      end
+    end
+
+    context 'session flushing' do
+      context 'on an alive mutation' do
+        with(:mutation_a_test_result) { { passed: true } }
+
+        it 'flushes the session file' do
+          subject
+
+          expect(Mutant::Result::JSONWriter)
+            .to have_received(:new).with(env:, result: object.status)
+          expect(writer).to have_received(:call)
+        end
+
+        context 'followed by another alive mutation' do
+          with(:mutation_b_test_result) { { passed: true } }
+
+          # Serializing the result tree is main-process work, so a burst
+          # of survivors must not turn into a burst of writes.
+          #
+          # Timer reads, in order: sink start, first flush check, the
+          # status snapshot taken by that flush, second flush check.
+          context 'within the flush interval' do
+            before do
+              allow(timer).to receive(:now).and_return(1.0, 1.0, 1.0, 1.999)
+            end
+
+            it 'flushes the session file only once' do
+              subject
+              object.response(mutation_b_index_response)
+
+              expect(writer).to have_received(:call).once
+            end
+          end
+
+          context 'after the flush interval' do
+            before do
+              allow(timer).to receive(:now).and_return(1.0, 1.0, 1.0, 2.0)
+            end
+
+            it 'flushes the session file again' do
+              subject
+              object.response(mutation_b_index_response)
+
+              expect(writer).to have_received(:call).twice
+            end
+          end
+        end
+      end
+
+      context 'on a killed mutation' do
+        it 'does not flush the session file' do
+          subject
+
+          expect(Mutant::Result::JSONWriter).not_to have_received(:new)
+        end
       end
     end
   end

--- a/ruby/spec/unit/mutant/result/json_writer_spec.rb
+++ b/ruby/spec/unit/mutant/result/json_writer_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Mutant::Result::JSONWriter do
   let(:dir)       { instance_double(Pathname, :dir) }
   let(:path)      { instance_double(Pathname, :path) }
+  let(:tmp_path)  { instance_double(Pathname, :tmp_path) }
   let(:pathname)  { class_double(Pathname) }
   let(:process)   { class_double(Process) }
 
@@ -29,7 +30,9 @@ RSpec.describe Mutant::Result::JSONWriter do
       allow(pathname).to receive(:new).with('.mutant/results').and_return(dir)
       allow(dir).to receive(:mkpath)
       allow(dir).to receive(:join).with("#{Mutant::SESSION_ID}.json").and_return(path)
-      allow(path).to receive(:write)
+      allow(dir).to receive(:join).with("#{Mutant::SESSION_ID}.json.tmp").and_return(tmp_path)
+      allow(tmp_path).to receive(:write)
+      allow(tmp_path).to receive(:rename)
       allow(process).to receive(:pid).and_return(42)
     end
 
@@ -39,10 +42,18 @@ RSpec.describe Mutant::Result::JSONWriter do
       expect(dir).to have_received(:mkpath)
     end
 
-    it 'writes JSON to the session file' do
+    # Written beside the session file and renamed over it, so a reader
+    # that opens the session mid-write never sees a truncated document.
+    it 'renames the temporary file over the session file' do
       object.call
 
-      expect(path).to have_received(:write) do |json|
+      expect(tmp_path).to have_received(:rename).with(path)
+    end
+
+    it 'writes JSON to the temporary file' do
+      object.call
+
+      expect(tmp_path).to have_received(:write) do |json|
         data = JSON.parse(json)
 
         expect(data.fetch('session_id')).to eql(Mutant::SESSION_ID)


### PR DESCRIPTION
The session JSON was written once, at the end of the run. On a long run that leaves survivors invisible to the session subcommands until the whole measurement finishes, which can be more than an hour after the report first printed them. The sink now rewrites the session file whenever a mutation result arrives uncovered, so the file always carries every survivor found so far.

The write goes to a temporary file that is renamed into place, so a reader opening the session mid-write never sees a truncated document. Killed mutations do not flush. The end of run write is unchanged.

Serializing the session is on the order of a second for a large project and runs on the main process, and alive mutations can arrive far faster than that. Flushes are therefore rate limited to one per second: the sink remembers the monotonic time of its last flush and skips any alive mutation that lands within a second of it. A survivor inside a suppressed window is picked up by the next flush, or by the final write in the runner. Fully killed runs write exactly as often as before (once).